### PR TITLE
Fix vulnerability in test project

### DIFF
--- a/DatabaseOperations.Tests/DatabaseOperations.Tests.csproj
+++ b/DatabaseOperations.Tests/DatabaseOperations.Tests.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NSubstitute" Version="4.4.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />


### PR DESCRIPTION
The Newtonsoft.Json package was pulled out during project clean up. Re-adding the package to override the version used in Microsoft.NET.Test.Sdk.