### PR TITLE
69 add action to set additional options

### DIFF
--- a/DatabaseOperations.Tests/Executors/SqlExecutorTests.cs
+++ b/DatabaseOperations.Tests/Executors/SqlExecutorTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace DatabaseOperations.Tests.Executors
 {
     using System.Collections.Generic;
+    using System.Data;
     using System.Threading;
     using System.Threading.Tasks;
     using DatabaseOperations.DataTransferObjects;
@@ -44,6 +45,32 @@
 
             // Act.
             result = sqlExecutor.ExecuteBackupPath(result, details);
+
+            // Assert.
+            result.Result.Should()
+                .BeTrue();
+        }
+
+        [Fact]
+        public void TestBackupPathActionWithValidDetailsReturnsTrue()
+        {
+            // Arrange.
+            ConnectionProperties connProps = new() { Server = "server", DatabaseName = "database", IntegratedSecurity = "True", ConnectTimeout = "5" };
+            SqlParameter dataParam = new() { ParameterName = "@Database", DbType = DbType.String };
+            BackupProperties backup = new()
+            {
+                BackupFileName = "BackupFile.bak",
+                BackupPath = BackupPath,
+                BackupParameters = new[] { dataParam },
+                CommandTimeout = 5,
+                Description = "Some backup",
+                ExecutionParameters = new[] { dataParam }
+            };
+
+            OperationResult result = new();
+
+            // Act.
+            result = sqlExecutor.ExecuteBackupPath(result, connProps, backup);
 
             // Assert.
             result.Result.Should()

--- a/DatabaseOperations.Tests/Executors/SqlExecutorTests.cs
+++ b/DatabaseOperations.Tests/Executors/SqlExecutorTests.cs
@@ -55,17 +55,8 @@
         public void TestBackupPathActionWithValidDetailsReturnsTrue()
         {
             // Arrange.
-            ConnectionProperties connProps = new() { Server = "server", DatabaseName = "database", IntegratedSecurity = "True", ConnectTimeout = "5" };
-            SqlParameter dataParam = new() { ParameterName = "@Database", DbType = DbType.String };
-            BackupProperties backup = new()
-            {
-                BackupFileName = "BackupFile.bak",
-                BackupPath = BackupPath,
-                BackupParameters = new[] { dataParam },
-                CommandTimeout = 5,
-                Description = "Some backup",
-                ExecutionParameters = new[] { dataParam }
-            };
+            ConnectionProperties connProps = GetValidConnectionProperties();
+            BackupProperties backup = GetValidBackupProperties();
 
             OperationResult result = new();
 
@@ -97,6 +88,27 @@
         }
 
         [Fact]
+        public async Task TestBackupPathAsyncActionWithValidDetailsReturnsTrue()
+        {
+            // Arrange.
+            ConnectionProperties connProps = GetValidConnectionProperties();
+            BackupProperties backup = GetValidBackupProperties();
+
+            OperationResult result = new();
+
+            // Act.
+            result = await sqlExecutor.ExecuteBackupPathAsync(
+                result,
+                connProps,
+                backup,
+                new CancellationToken());
+
+            // Assert.
+            result.Result.Should()
+                .BeTrue();
+        }
+
+        [Fact]
         public void TestBackupPathWithConnectionErrorReturnsFalse()
         {
             // Arrange.
@@ -112,6 +124,26 @@
 
             // Act.
             result = sqlExecutor.ExecuteBackupPath(result, details);
+
+            // Assert.
+            result.Result.Should()
+                .BeFalse();
+        }
+
+        [Fact]
+        public void TestBackupPathActionWithConnectionErrorReturnsFalse()
+        {
+            // Arrange.
+            ConnectionProperties connProps = GetValidConnectionProperties();
+            BackupProperties backup = GetValidBackupProperties();
+            connection
+                .When(c => c.Open())
+                .Do(_ => throw new DbTestException("Server is not correct!"));
+
+            OperationResult result = new();
+
+            // Act.
+            result = sqlExecutor.ExecuteBackupPath(result, connProps, backup);
 
             // Assert.
             result.Result.Should()
@@ -142,6 +174,31 @@
         }
 
         [Fact]
+        public async Task TestBackupPathAsyncActionWithConnectionErrorReturnsFalse()
+        {
+            // Arrange.
+            CancellationToken token = new();
+            ConnectionProperties connProps = GetValidConnectionProperties();
+            BackupProperties backup = GetValidBackupProperties();
+            connection
+                .When(c => c.OpenAsync(token))
+                .Do(_ => throw new DbTestException("Server is not correct!"));
+
+            OperationResult result = new();
+
+            // Act.
+            result = await sqlExecutor.ExecuteBackupPathAsync(
+                result,
+                connProps,
+                backup,
+                token);
+
+            // Assert.
+            result.Result.Should()
+                .BeFalse();
+        }
+
+        [Fact]
         public void TestBackupPathWithCommandParameterErrorReturnsFalse()
         {
             // Arrange.
@@ -157,6 +214,26 @@
 
             // Act.
             result = sqlExecutor.ExecuteBackupPath(result, details);
+
+            // Assert.
+            result.Result.Should()
+                .BeFalse();
+        }
+
+        [Fact]
+        public void TestBackupPathActionWithCommandParameterErrorReturnsFalse()
+        {
+            // Arrange.
+            ConnectionProperties connProps = GetValidConnectionProperties();
+            BackupProperties backup = GetValidBackupProperties();
+            command
+                .When(c => c.AddParameters(Arg.Any<SqlParameter[]>()))
+                .Do(_ => throw new DbTestException("Command is not working!"));
+
+            OperationResult result = new();
+
+            // Act.
+            result = sqlExecutor.ExecuteBackupPath(result, connProps, backup);
 
             // Assert.
             result.Result.Should()
@@ -186,6 +263,30 @@
         }
 
         [Fact]
+        public async Task TestBackupPathAsyncActionWithCommandParameterErrorReturnsFalse()
+        {
+            // Arrange.
+            ConnectionProperties connProps = GetValidConnectionProperties();
+            BackupProperties backup = GetValidBackupProperties();
+            command
+                .When(c => c.AddParameters(Arg.Any<SqlParameter[]>()))
+                .Do(_ => throw new DbTestException("Command is not working!"));
+
+            OperationResult result = new();
+
+            // Act.
+            result = await sqlExecutor.ExecuteBackupPathAsync(
+                result,
+                connProps,
+                backup,
+                new CancellationToken());
+
+            // Assert.
+            result.Result.Should()
+                .BeFalse();
+        }
+
+        [Fact]
         public void TestBackupPathWithCommandExecuteErrorReturnsFalse()
         {
             // Arrange.
@@ -201,6 +302,26 @@
 
             // Act.
             result = sqlExecutor.ExecuteBackupPath(result, details);
+
+            // Assert.
+            result.Result.Should()
+                .BeFalse();
+        }
+
+        [Fact]
+        public void TestBackupPathActionWithCommandExecuteErrorReturnsFalse()
+        {
+            // Arrange.
+            ConnectionProperties connProps = GetValidConnectionProperties();
+            BackupProperties backup = GetValidBackupProperties();
+            command
+                .When(c => c.ExecuteNonQuery())
+                .Do(_ => throw new DbTestException("Execute is not working!"));
+
+            OperationResult result = new();
+
+            // Act.
+            result = sqlExecutor.ExecuteBackupPath(result, connProps, backup);
 
             // Assert.
             result.Result.Should()
@@ -231,6 +352,31 @@
         }
 
         [Fact]
+        public async Task TestBackupPathAsyncActionWithCommandExecuteErrorReturnsFalse()
+        {
+            // Arrange.
+            CancellationToken token = new();
+            ConnectionProperties connProps = GetValidConnectionProperties();
+            BackupProperties backup = GetValidBackupProperties();
+            command
+                .When(c => c.ExecuteNonQueryAsync(token))
+                .Do(_ => throw new DbTestException("Execute is not working!"));
+
+            OperationResult result = new();
+
+            // Act.
+            result = await sqlExecutor.ExecuteBackupPathAsync(
+                result,
+                connProps,
+                backup,
+                token);
+
+            // Assert.
+            result.Result.Should()
+                .BeFalse();
+        }
+
+        [Fact]
         public void TestBackupPathWithCommandExecuteErrorReturnsExpectedMessages()
         {
             // Arrange.
@@ -251,6 +397,37 @@
 
             // Act.
             result = sqlExecutor.ExecuteBackupPath(result, details);
+
+            // Assert.
+            result.Messages.Should()
+                .HaveSameCount(expectedMessages);
+            result.Messages.Should()
+                .Equal(
+                    expectedMessages,
+                    (
+                        actualMessage,
+                        expectedMessage) => actualMessage.Contains(expectedMessage));
+        }
+
+        [Fact]
+        public void TestBackupPathActionWithCommandExecuteErrorReturnsExpectedMessages()
+        {
+            // Arrange.
+            ConnectionProperties connProps = GetValidConnectionProperties();
+            BackupProperties backup = GetValidBackupProperties();
+            command
+                .When(c => c.ExecuteNonQuery())
+                .Do(_ => throw new DbTestException("Execute is not working!"));
+
+            OperationResult result = new();
+
+            List<string> expectedMessages = new()
+            {
+                "Backup path folder check/create failed due to an exception."
+            };
+
+            // Act.
+            result = sqlExecutor.ExecuteBackupPath(result, connProps, backup);
 
             // Assert.
             result.Messages.Should()
@@ -298,6 +475,42 @@
         }
 
         [Fact]
+        public async Task TestBackupPathAsyncActionWithCommandExecuteErrorReturnsExpectedMessages()
+        {
+            // Arrange.
+            CancellationToken token = new();
+            ConnectionProperties connProps = GetValidConnectionProperties();
+            BackupProperties backup = GetValidBackupProperties();
+            command
+                .When(c => c.ExecuteNonQueryAsync(token))
+                .Do(_ => throw new DbTestException("Execute is not working!"));
+
+            OperationResult result = new();
+
+            List<string> expectedMessages = new()
+            {
+                "Backup path folder check/create failed due to an exception."
+            };
+
+            // Act.
+            result = await sqlExecutor.ExecuteBackupPathAsync(
+                result,
+                connProps,
+                backup,
+                token);
+
+            // Assert.
+            result.Messages.Should()
+                .HaveSameCount(expectedMessages);
+            result.Messages.Should()
+                .Equal(
+                    expectedMessages,
+                    (
+                        actualMessage,
+                        expectedMessage) => actualMessage.Contains(expectedMessage));
+        }
+
+        [Fact]
         public void TestBackupDatabaseWithValidDetailsReturnsTrue()
         {
             // Arrange.
@@ -310,6 +523,23 @@
 
             // Act.
             result = sqlExecutor.ExecuteBackupDatabase(result, details);
+
+            // Assert.
+            result.Result.Should()
+                .BeTrue();
+        }
+
+        [Fact]
+        public void TestBackupDatabaseActionWithValidDetailsReturnsTrue()
+        {
+            // Arrange.
+            ConnectionProperties connProps = GetValidConnectionProperties();
+            BackupProperties backup = GetValidBackupProperties();
+
+            OperationResult result = new();
+
+            // Act.
+            result = sqlExecutor.ExecuteBackupDatabase(result, connProps, backup);
 
             // Assert.
             result.Result.Should()
@@ -336,6 +566,27 @@
         }
 
         [Fact]
+        public async Task TestBackupDatabaseAsyncActionWithValidDetailsReturnsTrue()
+        {
+            // Arrange.
+            ConnectionProperties connProps = GetValidConnectionProperties();
+            BackupProperties backup = GetValidBackupProperties();
+
+            OperationResult result = new();
+
+            // Act.
+            result = await sqlExecutor.ExecuteBackupDatabaseAsync(
+                result,
+                connProps,
+                backup,
+                new CancellationToken());
+
+            // Assert.
+            result.Result.Should()
+                .BeTrue();
+        }
+
+        [Fact]
         public void TestBackupDatabaseWithConnectionErrorReturnsFalse()
         {
             // Arrange.
@@ -351,6 +602,26 @@
 
             // Act.
             result = sqlExecutor.ExecuteBackupDatabase(result, details);
+
+            // Assert.
+            result.Result.Should()
+                .BeFalse();
+        }
+
+        [Fact]
+        public void TestBackupDatabaseActionWithConnectionErrorReturnsFalse()
+        {
+            // Arrange.
+            ConnectionProperties connProps = GetValidConnectionProperties();
+            BackupProperties backup = GetValidBackupProperties();
+            connection
+                .When(c => c.Open())
+                .Do(_ => throw new DbTestException("Server is not correct!"));
+
+            OperationResult result = new();
+
+            // Act.
+            result = sqlExecutor.ExecuteBackupDatabase(result, connProps, backup);
 
             // Assert.
             result.Result.Should()
@@ -381,6 +652,31 @@
         }
 
         [Fact]
+        public async Task TestBackupDatabaseAsyncActionWithConnectionErrorReturnsFalse()
+        {
+            // Arrange.
+            CancellationToken token = new();
+            ConnectionProperties connProps = GetValidConnectionProperties();
+            BackupProperties backup = GetValidBackupProperties();
+            connection
+                .When(c => c.OpenAsync(token))
+                .Do(_ => throw new DbTestException("Server is not correct!"));
+
+            OperationResult result = new();
+
+            // Act.
+            result = await sqlExecutor.ExecuteBackupDatabaseAsync(
+                result,
+                connProps,
+                backup,
+                token);
+
+            // Assert.
+            result.Result.Should()
+                .BeFalse();
+        }
+
+        [Fact]
         public void TestBackupDatabaseWithCommandParameterErrorReturnsFalse()
         {
             // Arrange.
@@ -396,6 +692,26 @@
 
             // Act.
             result = sqlExecutor.ExecuteBackupDatabase(result, details);
+
+            // Assert.
+            result.Result.Should()
+                .BeFalse();
+        }
+
+        [Fact]
+        public void TestBackupDatabaseActionWithCommandParameterErrorReturnsFalse()
+        {
+            // Arrange.
+            ConnectionProperties connProps = GetValidConnectionProperties();
+            BackupProperties backup = GetValidBackupProperties();
+            command
+                .When(c => c.AddParameters(Arg.Any<SqlParameter[]>()))
+                .Do(_ => throw new DbTestException("Command is not working!"));
+
+            OperationResult result = new();
+
+            // Act.
+            result = sqlExecutor.ExecuteBackupDatabase(result, connProps, backup);
 
             // Assert.
             result.Result.Should()
@@ -425,6 +741,30 @@
         }
 
         [Fact]
+        public async Task TestBackupDatabaseAsyncActionWithCommandParameterErrorReturnsFalse()
+        {
+            // Arrange.
+            ConnectionProperties connProps = GetValidConnectionProperties();
+            BackupProperties backup = GetValidBackupProperties();
+            command
+                .When(c => c.AddParameters(Arg.Any<SqlParameter[]>()))
+                .Do(_ => throw new DbTestException("Command is not working!"));
+
+            OperationResult result = new();
+
+            // Act.
+            result = await sqlExecutor.ExecuteBackupDatabaseAsync(
+                result,
+                connProps,
+                backup,
+                new CancellationToken());
+
+            // Assert.
+            result.Result.Should()
+                .BeFalse();
+        }
+
+        [Fact]
         public void TestBackupDatabaseWithCommandExecuteErrorReturnsFalse()
         {
             // Arrange.
@@ -440,6 +780,26 @@
 
             // Act.
             result = sqlExecutor.ExecuteBackupDatabase(result, details);
+
+            // Assert.
+            result.Result.Should()
+                .BeFalse();
+        }
+
+        [Fact]
+        public void TestBackupDatabaseActionWithCommandExecuteErrorReturnsFalse()
+        {
+            // Arrange.
+            ConnectionProperties connProps = GetValidConnectionProperties();
+            BackupProperties backup = GetValidBackupProperties();
+            command
+                .When(c => c.ExecuteNonQuery())
+                .Do(_ => throw new DbTestException("Execute is not working!"));
+
+            OperationResult result = new();
+
+            // Act.
+            result = sqlExecutor.ExecuteBackupDatabase(result, connProps, backup);
 
             // Assert.
             result.Result.Should()
@@ -470,6 +830,31 @@
         }
 
         [Fact]
+        public async Task TestBackupDatabaseAsyncActionWithCommandExecuteErrorReturnsFalse()
+        {
+            // Arrange.
+            CancellationToken token = new();
+            ConnectionProperties connProps = GetValidConnectionProperties();
+            BackupProperties backup = GetValidBackupProperties();
+            command
+                .When(c => c.ExecuteNonQueryAsync(token))
+                .Do(_ => throw new DbTestException("Execute is not working!"));
+
+            OperationResult result = new();
+
+            // Act.
+            result = await sqlExecutor.ExecuteBackupDatabaseAsync(
+                result,
+                connProps,
+                backup,
+                token);
+
+            // Assert.
+            result.Result.Should()
+                .BeFalse();
+        }
+
+        [Fact]
         public void TestBackupDatabaseWithCommandExecuteErrorReturnsExpectedMessages()
         {
             // Arrange.
@@ -490,6 +875,37 @@
 
             // Act.
             result = sqlExecutor.ExecuteBackupDatabase(result, details);
+
+            // Assert.
+            result.Messages.Should()
+                .HaveSameCount(expectedMessages);
+            result.Messages.Should()
+                .Equal(
+                    expectedMessages,
+                    (
+                        actualMessage,
+                        expectedMessage) => actualMessage.Contains(expectedMessage));
+        }
+
+        [Fact]
+        public void TestBackupDatabaseActionWithCommandExecuteErrorReturnsExpectedMessages()
+        {
+            // Arrange.
+            ConnectionProperties connProps = GetValidConnectionProperties();
+            BackupProperties backup = GetValidBackupProperties();
+            command
+                .When(c => c.ExecuteNonQuery())
+                .Do(_ => throw new DbTestException("Execute is not working!"));
+
+            OperationResult result = new();
+
+            List<string> expectedMessages = new()
+            {
+                "Backing up the database failed due to an exception."
+            };
+
+            // Act.
+            result = sqlExecutor.ExecuteBackupDatabase(result, connProps, backup);
 
             // Assert.
             result.Messages.Should()
@@ -534,6 +950,64 @@
                     (
                         actualMessage,
                         expectedMessage) => actualMessage.Contains(expectedMessage));
+        }
+
+        [Fact]
+        public async Task TestBackupDatabaseAsyncActionWithCommandExecuteErrorReturnsExpectedMessages()
+        {
+            // Arrange.
+            CancellationToken token = new();
+            ConnectionProperties connProps = GetValidConnectionProperties();
+            BackupProperties backup = GetValidBackupProperties();
+            command
+                .When(c => c.ExecuteNonQueryAsync(token))
+                .Do(_ => throw new DbTestException("Execute is not working!"));
+
+            OperationResult result = new();
+
+            List<string> expectedMessages = new()
+            {
+                "Backing up the database failed due to an exception."
+            };
+
+            // Act.
+            result = await sqlExecutor.ExecuteBackupDatabaseAsync(
+                result,
+                connProps,
+                backup,
+                token);
+
+            // Assert.
+            result.Messages.Should()
+                .HaveSameCount(expectedMessages);
+            result.Messages.Should()
+                .Equal(
+                    expectedMessages,
+                    (
+                        actualMessage,
+                        expectedMessage) => actualMessage.Contains(expectedMessage));
+        }
+
+        private static BackupProperties GetValidBackupProperties()
+        {
+            SqlParameter dataParam = new() { ParameterName = "@Database", DbType = DbType.String };
+            BackupProperties backup = new()
+            {
+                BackupFileName = "BackupFile.bak",
+                BackupPath = BackupPath,
+                BackupParameters = new[] { dataParam },
+                CommandTimeout = 5,
+                Description = "Some backup",
+                ExecutionParameters = new[] { dataParam }
+            };
+            return backup;
+        }
+
+        private static ConnectionProperties GetValidConnectionProperties()
+        {
+            ConnectionProperties connProps = new()
+                { Server = "server", DatabaseName = "database", IntegratedSecurity = "True", ConnectTimeout = "5" };
+            return connProps;
         }
 
         private static ConnectionOptions GetConnectionOptions(

--- a/DatabaseOperations.Tests/Extensions/OperationResultExtensionTests.cs
+++ b/DatabaseOperations.Tests/Extensions/OperationResultExtensionTests.cs
@@ -1,13 +1,13 @@
 ﻿namespace DatabaseOperations.Tests.Extensions
 {
     using System.Collections.Generic;
-using System.Data;
+    using System.Data;
     using System.Threading;
     using System.Threading.Tasks;
     using DatabaseOperations.DataTransferObjects;
     using DatabaseOperations.Extensions;
     using FluentAssertions;
-using Interfaces;
+    using Interfaces;
     using Microsoft.Data.SqlClient;
     using NSubstitute;
     using Xunit;
@@ -24,8 +24,7 @@ using Interfaces;
                 .ApplyPassword("password")
                 .ApplyConnectTimeOut("205");
 
-            connectionProperties = new()
-                { Server = "server", DatabaseName = "database", IntegratedSecurity = "True", ConnectTimeout = "5" };
+            connectionProperties = new ConnectionProperties { Server = "server", DatabaseName = "database", IntegratedSecurity = "True", ConnectTimeout = "5" };
 
             SqlParameter dataParam = new() { ParameterName = "@Database", DbType = DbType.String };
             backupProperties = new()

--- a/DatabaseOperations.Tests/Operators/BackupOperatorTests.cs
+++ b/DatabaseOperations.Tests/Operators/BackupOperatorTests.cs
@@ -777,7 +777,7 @@
         internal async Task TestBackupAsyncActionWithCancelledBackupPathReturnsFalse()
         {
             // Arrange.
-            CancellationTokenSource source = new(400);
+            CancellationTokenSource source = new(100);
             CancellationToken token = source.Token;
             token.ThrowIfCancellationRequested();
 

--- a/DatabaseOperations.Tests/Operators/BackupOperatorTests.cs
+++ b/DatabaseOperations.Tests/Operators/BackupOperatorTests.cs
@@ -131,8 +131,7 @@
                 {
                     options.BackupPath = BackupPath;
                     options.Timeout = 100;
-                },
-                new CancellationToken());
+                });
 
             // Assert.
             result.Result.Should()
@@ -270,8 +269,7 @@
                 {
                     options.BackupPath = BackupPath;
                     options.Timeout = 100;
-                },
-                new CancellationToken());
+                });
 
             // Assert.
             result.Result.Should()
@@ -434,8 +432,7 @@
                 {
                     options.BackupPath = BackupPath;
                     options.Timeout = 100;
-                },
-                new CancellationToken());
+                });
 
             // Assert.
             result.Messages.Should()
@@ -573,8 +570,7 @@
                 {
                     options.BackupPath = BackupPath;
                     options.Timeout = 100;
-                },
-                new CancellationToken());
+                });
 
             // Assert.
             result.Result.Should()
@@ -728,8 +724,7 @@
                 {
                     options.BackupPath = BackupPath;
                     options.Timeout = 100;
-                },
-                new CancellationToken());
+                });
 
             // Assert.
             result.Messages.Should()
@@ -782,7 +777,7 @@
         internal async Task TestBackupAsyncActionWithCancelledBackupPathReturnsFalse()
         {
             // Arrange.
-            CancellationTokenSource source = new(100);
+            CancellationTokenSource source = new(400);
             CancellationToken token = source.Token;
             token.ThrowIfCancellationRequested();
 
@@ -801,7 +796,7 @@
                         Arg.Any<BackupProperties>(),
                         Arg.Any<CancellationToken>()))
                 .Do(_ => Thread.Sleep(500));
-            const string connectionString = "server=server;database=database;user id=user;password=password";
+            const string connectionString = "server=server;database=database;user id=user;password=password;Connect Timeout=10;";
 
             // Act.
             OperationResult result = await backupOperator.BackupDatabaseAsync(
@@ -891,7 +886,7 @@
                         Arg.Any<BackupProperties>(),
                         Arg.Any<CancellationToken>()))
                 .Do(_ => Thread.Sleep(500));
-            const string connectionString = "server=server;database=database;user id=user;password=password";
+            const string connectionString = "server=server;database=database;user id=user;password=password;Connect Timeout=10;";
 
             // Act.
             OperationResult result = await backupOperator.BackupDatabaseAsync(

--- a/DatabaseOperations.Tests/Operators/BackupOperatorTests.cs
+++ b/DatabaseOperations.Tests/Operators/BackupOperatorTests.cs
@@ -74,11 +74,34 @@
                 .BeTrue();
         }
 
+        /// <summary>
+        /// A test example on how to use the action for database options.
+        /// Not a real unit test.
+        /// </summary>
+        [Fact]
+        public void TestBackupWithNewOptions()
+        {
+            // Arrange.
+            string connectionString = "server=server;database=database;user id=user;password=password";
+
+            // Act.
+            OperationResult result = backupOperator.BackupDatabase(
+                connectionString,
+                options =>
+                {
+                    options.BackupPath = BackupPath;
+                    options.Timeout = 100;
+                });
+
+            // Assert.
+        }
+
         [Fact]
         public void TestBackupWithPathErrorReturnsTrue()
         {
             // Arrange.
-            OperationResult defaultResult = new() { Result = true, Messages = new List<string> { "Backup path folder check/create failed due to an exception." } };
+            OperationResult defaultResult = new()
+                { Result = true, Messages = new List<string> { "Backup path folder check/create failed due to an exception." } };
             ConnectionOptions details = GetConnectionOptions(
                 "server",
                 "database",
@@ -105,7 +128,8 @@
         public async Task TestBackupAsyncWithPathErrorReturnsTrue()
         {
             // Arrange.
-            OperationResult defaultResult = new() { Result = true, Messages = new List<string> { "Backup path folder check/create failed due to an exception." } };
+            OperationResult defaultResult = new()
+                { Result = true, Messages = new List<string> { "Backup path folder check/create failed due to an exception." } };
             ConnectionOptions details = GetConnectionOptions(
                 "server",
                 "database",

--- a/DatabaseOperations.Tests/Services/BackupParameterServiceTests.cs
+++ b/DatabaseOperations.Tests/Services/BackupParameterServiceTests.cs
@@ -8,7 +8,7 @@
     using DatabaseOperations.Services;
     using FluentAssertions;
     using Interfaces;
-using Microsoft.Data.SqlClient;
+    using Microsoft.Data.SqlClient;
     using NSubstitute;
     using Options;
     using Xunit;
@@ -226,7 +226,7 @@ using Microsoft.Data.SqlClient;
         private static ConnectionProperties GetValidConnectionProperties()
         {
             ConnectionProperties connProps = new()
-                { Server = "server", DatabaseName = "database", IntegratedSecurity = "True", ConnectTimeout = "5" };
+            { Server = "server", DatabaseName = "database", IntegratedSecurity = "True", ConnectTimeout = "5" };
             return connProps;
         }
     }

--- a/DatabaseOperations.Tests/Services/BackupParameterServiceTests.cs
+++ b/DatabaseOperations.Tests/Services/BackupParameterServiceTests.cs
@@ -1,0 +1,233 @@
+﻿namespace DatabaseOperations.Tests.Services
+{
+    using System;
+    using System.Data;
+    using System.Linq;
+    using Constants;
+    using DatabaseOperations.DataTransferObjects;
+    using DatabaseOperations.Services;
+    using FluentAssertions;
+    using Interfaces;
+using Microsoft.Data.SqlClient;
+    using NSubstitute;
+    using Options;
+    using Xunit;
+
+    public class BackupParameterServiceTests
+    {
+        public BackupParameterServiceTests()
+        {
+            DateTimeWrapper.Now.Returns(
+                new DateTime(
+                    2021,
+                    08,
+                    11,
+                    15,
+                    52,
+                    08));
+        }
+
+        private static readonly IDateTimeWrapper DateTimeWrapper = Substitute.For<IDateTimeWrapper>();
+
+        [Fact]
+        public void TestGetPropertiesWithValidDataReturnsDefaultProperties()
+        {
+            // Arrange.
+            OperatorOptions options = new() { BackupPath = @"C:\Backups\", Timeout = 10 };
+
+            // Act.
+            BackupProperties actual = BackupParameterService.GetBackupPropertiesForTests(
+                GetValidConnectionProperties(),
+                options,
+                DateTimeWrapper);
+
+            // Assert.
+            actual.Should()
+                .BeOfType<BackupProperties>()
+                .Which.Should()
+                .NotBeNull();
+        }
+
+        [Fact]
+        public void TestGetPropertiesWithValidDataReturnsExpectedFileName()
+        {
+            // Arrange.
+            OperatorOptions options = new() { BackupPath = @"C:\Backups\", Timeout = 10 };
+
+            // Act.
+            BackupProperties actual = BackupParameterService.GetBackupPropertiesForTests(
+                GetValidConnectionProperties(),
+                options,
+                DateTimeWrapper);
+
+            // Assert.
+            actual.BackupFileName.Should()
+                .Be("database_Full_2021-08-11-15-52-08.bak");
+        }
+
+        [Fact]
+        public void TestGetPropertiesWithValidDataReturnsExpectedDescription()
+        {
+            // Arrange.
+            OperatorOptions options = new() { BackupPath = @"C:\Backups\", Timeout = 10 };
+
+            // Act.
+            BackupProperties actual = BackupParameterService.GetBackupPropertiesForTests(
+                GetValidConnectionProperties(),
+                options,
+                DateTimeWrapper);
+
+            // Assert.
+            actual.Description.Should()
+                .Be("Full backup of the `database` database.");
+        }
+
+        [Theory]
+        [InlineData(10, 10)]
+        [InlineData(1, 1)]
+        [InlineData(10000, 10000)]
+        [InlineData(0, 3600)]
+        public void TestGetPropertiesWithValidDataReturnsTimeout(
+            int timeout,
+            int expected)
+        {
+            // Arrange.
+            OperatorOptions options = new() { BackupPath = @"C:\Backups\", Timeout = timeout };
+
+            // Act.
+            BackupProperties actual = BackupParameterService.GetBackupPropertiesForTests(
+                GetValidConnectionProperties(),
+                options,
+                DateTimeWrapper);
+
+            // Assert.
+            actual.CommandTimeout.Should()
+                .Be(expected);
+        }
+
+        [Fact]
+        public void TestGetPropertiesWithValidDataReturnsExpectedBackupPath()
+        {
+            // Arrange.
+            OperatorOptions options = new() { BackupPath = @"C:\Backups\", Timeout = 10 };
+
+            // Act.
+            BackupProperties actual = BackupParameterService.GetBackupPropertiesForTests(
+                GetValidConnectionProperties(),
+                options,
+                DateTimeWrapper);
+
+            // Assert.
+            actual.BackupPath.Should()
+                .Be(options.BackupPath);
+        }
+
+        [Fact]
+        public void TestGetPropertiesWithValidDataReturnsExpectedBackupParameters()
+        {
+            // Arrange.
+            OperatorOptions options = new() { BackupPath = @"C:\Backups\", Timeout = 10 };
+
+            // Act.
+            BackupProperties actual = BackupParameterService.GetBackupPropertiesForTests(
+                GetValidConnectionProperties(),
+                options,
+                DateTimeWrapper);
+
+            // Assert.
+            actual.BackupParameters.Should()
+                .HaveCount(1);
+            actual.BackupParameters[0]
+                .SqlDbType.Should()
+                .Be(SqlDbType.VarChar);
+            actual.BackupParameters[0]
+                .Value.Should()
+                .Be(options.BackupPath);
+        }
+
+        [Fact]
+        public void TestGetPropertiesWithValidDataReturnsExpectedExecutionNameParameter()
+        {
+            // Arrange.
+            OperatorOptions options = new() { BackupPath = @"C:\Backups\", Timeout = 10 };
+
+            // Act.
+            BackupProperties actual = BackupParameterService.GetBackupPropertiesForTests(
+                GetValidConnectionProperties(),
+                options,
+                DateTimeWrapper);
+
+            SqlParameter[] actualParameters = actual.ExecutionParameters;
+
+            // Assert.
+            actualParameters.Should()
+                .HaveCount(3);
+
+            string? actualNameValue = actualParameters.First(p => p.ParameterName == Parameters.NameParameter)
+                .Value.ToString();
+            actualNameValue.Should()
+                .NotBeNullOrWhiteSpace();
+            actualNameValue.Should()
+                .Be("database");
+        }
+
+        [Fact]
+        public void TestGetPropertiesWithValidDataReturnsExpectedExecutionLocationParameter()
+        {
+            // Arrange.
+            OperatorOptions options = new() { BackupPath = @"C:\Backups\", Timeout = 10 };
+
+            // Act.
+            BackupProperties actual = BackupParameterService.GetBackupPropertiesForTests(
+                GetValidConnectionProperties(),
+                options,
+                DateTimeWrapper);
+
+            SqlParameter[] actualParameters = actual.ExecutionParameters;
+
+            // Assert.
+            actualParameters.Should()
+                .HaveCount(3);
+
+            string? actualLocationValue = actualParameters.First(p => p.ParameterName == Parameters.LocationParameter)
+                .Value.ToString();
+            actualLocationValue.Should()
+                .NotBeNullOrWhiteSpace();
+            actualLocationValue.Should()
+                .Be(@"C:\Backups\" + "database_Full_2021-08-11-15-52-08.bak");
+        }
+
+        [Fact]
+        public void TestGetPropertiesWithValidDataReturnsExpectedExecutionDescriptionParameter()
+        {
+            // Arrange.
+            OperatorOptions options = new() { BackupPath = @"C:\Backups\", Timeout = 10 };
+
+            // Act.
+            BackupProperties actual = BackupParameterService.GetBackupPropertiesForTests(
+                GetValidConnectionProperties(),
+                options,
+                DateTimeWrapper);
+
+            SqlParameter[] actualParameters = actual.ExecutionParameters;
+
+            // Assert.
+            actualParameters.Should()
+                .HaveCount(3);
+
+            string? actualDescriptionValue = actualParameters.First(p => p.ParameterName == Parameters.DescriptionParameter)
+                .Value.ToString();
+            actualDescriptionValue.Should()
+                .NotBeNullOrWhiteSpace();
+            actualDescriptionValue.Should()
+                .Be("Full backup of the `database` database.");
+        }
+
+        private static ConnectionProperties GetValidConnectionProperties()
+        {
+            ConnectionProperties connProps = new()
+                { Server = "server", DatabaseName = "database", IntegratedSecurity = "True", ConnectTimeout = "5" };
+            return connProps;
+        }
+    }
+}

--- a/DatabaseOperations.Tests/Services/ConnectionStringServiceTests.cs
+++ b/DatabaseOperations.Tests/Services/ConnectionStringServiceTests.cs
@@ -77,6 +77,19 @@
         }
 
         [Theory]
+        [MemberData(nameof(ConnectionStrings))]
+        internal void TestExtractWithValidDataReturnsExpectedConnectionString(string connection)
+        {
+            // Arrange.
+            // Act.
+            ConnectionProperties actual = ConnectionStringService.ExtractConnectionParameters(connection);
+
+            // Assert.
+            actual.ConnectionString.Should()
+                .NotBeNullOrWhiteSpace();
+        }
+
+        [Theory]
         [MemberData(nameof(UserConnectionStrings))]
         internal void TestExtractWithValidDataReturnsExpectedUserId(string connection)
         {

--- a/DatabaseOperations.Tests/Services/ConnectionStringServiceTests.cs
+++ b/DatabaseOperations.Tests/Services/ConnectionStringServiceTests.cs
@@ -1,0 +1,248 @@
+﻿namespace DatabaseOperations.Tests.Services
+{
+    using System.Collections.Generic;
+    using DatabaseOperations.DataTransferObjects;
+    using DatabaseOperations.Services;
+    using FluentAssertions;
+    using Xunit;
+
+    public class ConnectionStringServiceTests
+    {
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        internal void TestExtractWithEmptyConnectionStringReturnsNewProperties(string connection)
+        {
+            // Arrange.
+            // Act.
+            ConnectionProperties actual = ConnectionStringService.ExtractConnectionParameters(connection);
+
+            // Assert.
+            actual.Should()
+                .BeOfType<ConnectionProperties>()
+                .Subject.Should()
+                .NotBeNull();
+        }
+
+        [Theory]
+        [MemberData(nameof(ConnectionStrings))]
+        internal void TestExtractWithValidDataReturnsExpectedServer(string connection)
+        {
+            // Arrange.
+            // Act.
+            ConnectionProperties actual = ConnectionStringService.ExtractConnectionParameters(connection);
+
+            // Assert.
+            actual.Server.Should()
+                .Be("127.0.0.1");
+        }
+
+        [Theory]
+        [MemberData(nameof(ConnectionStrings))]
+        internal void TestExtractWithValidDataReturnsExpectedDatabase(string connection)
+        {
+            // Arrange.
+            // Act.
+            ConnectionProperties actual = ConnectionStringService.ExtractConnectionParameters(connection);
+
+            // Assert.
+            actual.DatabaseName.Should()
+                .Be("Bananas");
+        }
+
+        [Theory]
+        [MemberData(nameof(ConnectionStrings))]
+        internal void TestExtractWithValidDataReturnsExpectedAndChangedTimeout(string connection)
+        {
+            // Arrange.
+            // Act.
+            ConnectionProperties actual = ConnectionStringService.ExtractConnectionParameters(connection);
+
+            // Assert.
+            actual.ConnectTimeout.Should()
+                .Be("205");
+        }
+
+        [Theory]
+        [MemberData(nameof(ConnectionStrings))]
+        internal void TestExtractWithValidDataReturnsExpectedApplicationName(string connection)
+        {
+            // Arrange.
+            // Act.
+            ConnectionProperties actual = ConnectionStringService.ExtractConnectionParameters(connection);
+
+            // Assert.
+            actual.ApplicationName.Should()
+                .Be("Test App");
+        }
+
+        [Theory]
+        [MemberData(nameof(UserConnectionStrings))]
+        internal void TestExtractWithValidDataReturnsExpectedUserId(string connection)
+        {
+            // Arrange.
+            // Act.
+            ConnectionProperties actual = ConnectionStringService.ExtractConnectionParameters(connection);
+
+            // Assert.
+            actual.UserId.Should()
+                .Be("sa");
+        }
+
+        [Theory]
+        [MemberData(nameof(UserConnectionStrings))]
+        internal void TestExtractWithValidDataReturnsExpectedPassword(string connection)
+        {
+            // Arrange.
+            // Act.
+            ConnectionProperties actual = ConnectionStringService.ExtractConnectionParameters(connection);
+
+            // Assert.
+            actual.Password.Should()
+                .Be("p@55word1");
+        }
+
+        [Theory]
+        [MemberData(nameof(TrustedConnectionStrings))]
+        internal void TestExtractWithValidDataReturnsExpectedSecurity(
+            string connection,
+            string expectedConnection)
+        {
+            // Arrange.
+            // Act.
+            ConnectionProperties actual = ConnectionStringService.ExtractConnectionParameters(connection);
+
+            // Assert.
+            actual.IntegratedSecurity.Should()
+                .Be(expectedConnection);
+        }
+
+        internal static IEnumerable<object[]> ConnectionStrings()
+        {
+            yield return new object[]
+            {
+                "server=127.0.0.1;database=Bananas;User Id=sa;Password=p@55word1;Connect Timeout=205;application name=Test App;"
+            };
+            yield return new object[]
+            {
+                "data source=127.0.0.1;database=Bananas;User Id=sa;Password=p@55word1;Connect Timeout=205;application name=Test App;"
+            };
+            yield return new object[]
+            {
+                "address=127.0.0.1;database=Bananas;User Id=sa;Password=p@55word1;Connect Timeout=205;application name=Test App;"
+            };
+            yield return new object[]
+            {
+                "addr=127.0.0.1;database=Bananas;User Id=sa;Password=p@55word1;Connect Timeout=205;application name=Test App;"
+            };
+            yield return new object[]
+            {
+                "network address=127.0.0.1;database=Bananas;User Id=sa;Password=p@55word1;Connect Timeout=205;application name=Test App;"
+            };
+            yield return new object[]
+            {
+                "server=127.0.0.1;database=Bananas;User Id=sa;Password=p@55word1;Connection Timeout=205;application name=Test App;"
+            };
+            yield return new object[]
+            {
+                "server=127.0.0.1;initial catalog=Bananas;User Id=sa;Password=p@55word1;Connect Timeout=205;application name=Test App;"
+            };
+            yield return new object[]
+            {
+                "server=127.0.0.1;database=Bananas;Integrated Security=True;Connect Timeout=205;application name=Test App;"
+            };
+            yield return new object[]
+            {
+                "server=127.0.0.1;database=Bananas;Integrated Security=False;Connect Timeout=205;application name=Test App;"
+            };
+            yield return new object[]
+            {
+                "server=127.0.0.1;database=Bananas;Integrated Security=SSPI;Connect Timeout=205;application name=Test App;"
+            };
+            yield return new object[]
+            {
+                "server=127.0.0.1;database=Bananas;Trusted_Connection=True;Connect Timeout=205;application name=Test App;"
+            };
+            yield return new object[]
+            {
+                "server=127.0.0.1;database=Bananas;Trusted_Connection=False;Connect Timeout=205;application name=Test App;"
+            };
+            yield return new object[]
+            {
+                "server=127.0.0.1;database=Bananas;Trusted_Connection=sspi;Connect Timeout=205;application name=Test App;"
+            };
+            yield return new object[]
+            {
+                "server=127.0.0.1;database=Bananas;User Id=sa;pwd=p@55word1;Connect Timeout=205;application name=Test App;"
+            };
+        }
+
+        internal static IEnumerable<object[]> UserConnectionStrings()
+        {
+            yield return new object[]
+            {
+                "server=127.0.0.1;database=Bananas;User Id=sa;Password=p@55word1;Connect Timeout=205;application name=Test App;"
+            };
+            yield return new object[]
+            {
+                "data source=127.0.0.1;database=Bananas;User Id=sa;Password=p@55word1;Connect Timeout=205;application name=Test App;"
+            };
+            yield return new object[]
+            {
+                "address=127.0.0.1;database=Bananas;User Id=sa;Password=p@55word1;Connect Timeout=205;application name=Test App;"
+            };
+            yield return new object[]
+            {
+                "addr=127.0.0.1;database=Bananas;User Id=sa;Password=p@55word1;Connect Timeout=205;application name=Test App;"
+            };
+            yield return new object[]
+            {
+                "network address=127.0.0.1;database=Bananas;User Id=sa;Password=p@55word1;Connect Timeout=205;application name=Test App;"
+            };
+            yield return new object[]
+            {
+                "server=127.0.0.1;database=Bananas;User Id=sa;Password=p@55word1;Connection Timeout=205;application name=Test App;"
+            };
+            yield return new object[]
+            {
+                "server=127.0.0.1;initial catalog=Bananas;User Id=sa;Password=p@55word1;Connect Timeout=205;application name=Test App;"
+            };
+            yield return new object[]
+            {
+                "server=127.0.0.1;database=Bananas;User Id=sa;pwd=p@55word1;Connect Timeout=205;application name=Test App;"
+            };
+        }
+
+        internal static IEnumerable<object[]> TrustedConnectionStrings()
+        {
+            yield return new object[]
+            {
+                "server=127.0.0.1;database=Bananas;Integrated Security=True;Connect Timeout=205;application name=Test App;",
+                "True"
+            };
+            yield return new object[]
+            {
+                "server=127.0.0.1;database=Bananas;Integrated Security=False;Connect Timeout=205;application name=Test App;",
+                "False"
+            };
+            yield return new object[]
+            {
+                "server=127.0.0.1;database=Bananas;Integrated Security=SSPI;Connect Timeout=205;application name=Test App;",
+                "SSPI"
+            };
+            yield return new object[]
+            {
+                "server=127.0.0.1;database=Bananas;Trusted_Connection=True;Connect Timeout=205;application name=Test App;", "True"
+            };
+            yield return new object[]
+            {
+                "server=127.0.0.1;database=Bananas;Trusted_Connection=False;Connect Timeout=205;application name=Test App;",
+                "False"
+            };
+            yield return new object[]
+            {
+                "server=127.0.0.1;database=Bananas;Trusted_Connection=sspi;Connect Timeout=205;application name=Test App;", "sspi"
+            };
+        }
+    }
+}

--- a/DatabaseOperations.Tests/Validators/ConnectionPropertiesValidatorTests.cs
+++ b/DatabaseOperations.Tests/Validators/ConnectionPropertiesValidatorTests.cs
@@ -1,0 +1,157 @@
+﻿namespace DatabaseOperations.Tests.Validators
+{
+    using System.Collections.Generic;
+    using DatabaseOperations.DataTransferObjects;
+    using DatabaseOperations.Extensions;
+    using DatabaseOperations.Validators;
+    using FluentAssertions;
+    using FluentValidation.Results;
+    using Xunit;
+
+    public class ConnectionPropertiesValidatorTests
+    {
+        [Fact]
+        public void TestIsValidWithValidPropertiesReturnsTrue()
+        {
+            // Arrange.
+            ConnectionProperties properties = new()
+                { Server = "127.0.0.1", DatabaseName = "Bananas", ConnectTimeout = "5", UserId = "1", Password = "password" };
+
+            // Act.
+            ValidationResult validationResult = properties.CheckValidation(new ConnectionPropertiesValidator());
+
+            // Assert.
+            validationResult.IsValid.Should()
+                .BeTrue();
+        }
+
+        [Theory]
+        [InlineData("SSPI")]
+        [InlineData("True")]
+        [InlineData("False")]
+        public void TestIsValidWithSecuritySetAndMissingUserReturnsTrue(string security)
+        {
+            // Arrange.
+            ConnectionProperties properties = new()
+                { Server = "127.0.0.1", DatabaseName = "Bananas", ConnectTimeout = "5", IntegratedSecurity = security };
+
+            // Act.
+            ValidationResult validationResult = properties.CheckValidation(new ConnectionPropertiesValidator());
+
+            // Assert.
+            validationResult.IsValid.Should()
+                .BeTrue();
+        }
+
+        [Fact]
+        public void TestIsValidWithMissingServerReturnsFalse()
+        {
+            // Arrange.
+            ConnectionProperties properties = new()
+                { DatabaseName = "Bananas", ConnectTimeout = "5", IntegratedSecurity = "SSPI" };
+
+            // Act.
+            ValidationResult validationResult = properties.CheckValidation(new ConnectionPropertiesValidator());
+
+            // Assert.
+            validationResult.IsValid.Should()
+                .BeFalse();
+        }
+
+        [Fact]
+        public void TestIsValidWithMissingDatabaseReturnsFalse()
+        {
+            // Arrange.
+            ConnectionProperties properties = new()
+                { Server = "127.0.0.1", ConnectTimeout = "5", IntegratedSecurity = "SSPI" };
+
+            // Act.
+            ValidationResult validationResult = properties.CheckValidation(new ConnectionPropertiesValidator());
+
+            // Assert.
+            validationResult.IsValid.Should()
+                .BeFalse();
+        }
+
+        [Fact]
+        public void TestIsValidWithMissingUserAndSecurityReturnsFalse()
+        {
+            // Arrange.
+            ConnectionProperties properties = new()
+                { Server = "127.0.0.1", DatabaseName = "Bananas", ConnectTimeout = "5" };
+
+            // Act.
+            ValidationResult validationResult = properties.CheckValidation(new ConnectionPropertiesValidator());
+
+            // Assert.
+            validationResult.IsValid.Should()
+                .BeFalse();
+        }
+
+        [Theory]
+        [MemberData(nameof(ConnectionProperties))]
+        public void TestIsValidWithInvalidPropertiesReturnsFalse(ConnectionProperties properties)
+        {
+            // Arrange.
+            // Act.
+            ValidationResult validationResult = properties.CheckValidation(new ConnectionPropertiesValidator());
+
+            // Assert.
+            validationResult.IsValid.Should()
+                .BeFalse();
+        }
+
+        internal static IEnumerable<object[]> ConnectionProperties()
+        {
+            yield return new object[]
+            {
+                new ConnectionProperties
+                {
+                    DatabaseName = "Bananas", ConnectTimeout = "5", IntegratedSecurity = "SSPI"
+                }
+            };
+            yield return new object[]
+            {
+                new ConnectionProperties
+                {
+                    Server = "   ", DatabaseName = "Bananas", ConnectTimeout = "5", IntegratedSecurity = "SSPI"
+                }
+            };
+            yield return new object[]
+            {
+                new ConnectionProperties
+                {
+                    Server = "127.0.0.1", ConnectTimeout = "5", IntegratedSecurity = "SSPI"
+                }
+            };
+            yield return new object[]
+            {
+                new ConnectionProperties
+                {
+                    Server = "127.0.0.1", DatabaseName = "  ", ConnectTimeout = "5", IntegratedSecurity = "SSPI"
+                }
+            };
+            yield return new object[]
+            {
+                new ConnectionProperties
+                {
+                    Server = "127.0.0.1", DatabaseName = "Bananas", ConnectTimeout = "5"
+                }
+            };
+            yield return new object[]
+            {
+                new ConnectionProperties
+                {
+                    Server = "127.0.0.1", DatabaseName = "Bananas", ConnectTimeout = "-1", IntegratedSecurity = "SSPI"
+                }
+            };
+            yield return new object[]
+            {
+                new ConnectionProperties
+                {
+                    Server = "127.0.0.1", DatabaseName = "Bananas", ConnectTimeout = "5", IntegratedSecurity = "hello"
+                }
+            };
+        }
+    }
+}

--- a/DatabaseOperations/ConnectionRules/AbbreviatedAddressConnectionRule.cs
+++ b/DatabaseOperations/ConnectionRules/AbbreviatedAddressConnectionRule.cs
@@ -21,5 +21,13 @@
             if (string.IsNullOrWhiteSpace(options.Server)) options.Server = AbbreviatedAddressLookUp.ToValue(item);
             return options;
         }
+
+        public ConnectionProperties ApplyChange(
+            ConnectionProperties properties,
+            string item)
+        {
+            if (string.IsNullOrWhiteSpace(properties.Server)) properties.Server = AbbreviatedAddressLookUp.ToValue(item);
+            return properties;
+        }
     }
 }

--- a/DatabaseOperations/ConnectionRules/AbbreviatedPasswordConnectionRule.cs
+++ b/DatabaseOperations/ConnectionRules/AbbreviatedPasswordConnectionRule.cs
@@ -21,5 +21,13 @@
             if (string.IsNullOrWhiteSpace(options.Password)) options.Password = AbbreviatedPasswordLookUp.ToValue(item);
             return options;
         }
+
+        public ConnectionProperties ApplyChange(
+            ConnectionProperties properties,
+            string item)
+        {
+            if (string.IsNullOrWhiteSpace(properties.Password)) properties.Password = AbbreviatedPasswordLookUp.ToValue(item);
+            return properties;
+        }
     }
 }

--- a/DatabaseOperations/ConnectionRules/AddressConnectionRule.cs
+++ b/DatabaseOperations/ConnectionRules/AddressConnectionRule.cs
@@ -21,5 +21,13 @@
             if (string.IsNullOrWhiteSpace(options.Server)) options.Server = AddressLookUp.ToValue(item);
             return options;
         }
+
+        public ConnectionProperties ApplyChange(
+            ConnectionProperties properties,
+            string item)
+        {
+            if (string.IsNullOrWhiteSpace(properties.Server)) properties.Server = AddressLookUp.ToValue(item);
+            return properties;
+        }
     }
 }

--- a/DatabaseOperations/ConnectionRules/ApplicationConnectionRule.cs
+++ b/DatabaseOperations/ConnectionRules/ApplicationConnectionRule.cs
@@ -21,5 +21,13 @@
             if (string.IsNullOrWhiteSpace(options.ApplicationName)) options.ApplicationName = ApplicationNameLookUp.ToValue(item);
             return options;
         }
+
+        public ConnectionProperties ApplyChange(
+            ConnectionProperties properties,
+            string item)
+        {
+            if (string.IsNullOrWhiteSpace(properties.ApplicationName)) properties.ApplicationName = ApplicationNameLookUp.ToValue(item);
+            return properties;
+        }
     }
 }

--- a/DatabaseOperations/ConnectionRules/CatalogConnectionRule.cs
+++ b/DatabaseOperations/ConnectionRules/CatalogConnectionRule.cs
@@ -21,5 +21,13 @@
             if (string.IsNullOrWhiteSpace(options.DatabaseName)) options.DatabaseName = InitialCatalogLookUp.ToValue(item);
             return options;
         }
+
+        public ConnectionProperties ApplyChange(
+            ConnectionProperties properties,
+            string item)
+        {
+            if (string.IsNullOrWhiteSpace(properties.DatabaseName)) properties.DatabaseName = InitialCatalogLookUp.ToValue(item);
+            return properties;
+        }
     }
 }

--- a/DatabaseOperations/ConnectionRules/ConnectTimeoutConnectionRule.cs
+++ b/DatabaseOperations/ConnectionRules/ConnectTimeoutConnectionRule.cs
@@ -21,5 +21,13 @@
             if (string.IsNullOrWhiteSpace(options.ConnectTimeout)) options.ConnectTimeout = ConnectTimeoutLookUp.ToValue(item);
             return options;
         }
+
+        public ConnectionProperties ApplyChange(
+            ConnectionProperties properties,
+            string item)
+        {
+            if (string.IsNullOrWhiteSpace(properties.ConnectTimeout)) properties.ConnectTimeout = ConnectTimeoutLookUp.ToValue(item);
+            return properties;
+        }
     }
 }

--- a/DatabaseOperations/ConnectionRules/ConnectionTimeoutConnectionRule.cs
+++ b/DatabaseOperations/ConnectionRules/ConnectionTimeoutConnectionRule.cs
@@ -21,5 +21,13 @@
             if (string.IsNullOrWhiteSpace(options.ConnectTimeout)) options.ConnectTimeout = ConnectionTimeoutLookUp.ToValue(item);
             return options;
         }
+
+        public ConnectionProperties ApplyChange(
+            ConnectionProperties properties,
+            string item)
+        {
+            if (string.IsNullOrWhiteSpace(properties.ConnectTimeout)) properties.ConnectTimeout = ConnectionTimeoutLookUp.ToValue(item);
+            return properties;
+        }
     }
 }

--- a/DatabaseOperations/ConnectionRules/DataSourceConnectionRule.cs
+++ b/DatabaseOperations/ConnectionRules/DataSourceConnectionRule.cs
@@ -21,5 +21,13 @@
             if (string.IsNullOrWhiteSpace(options.Server)) options.Server = DataSourceLookUp.ToValue(item);
             return options;
         }
+
+        public ConnectionProperties ApplyChange(
+            ConnectionProperties properties,
+            string item)
+        {
+            if (string.IsNullOrWhiteSpace(properties.Server)) properties.Server = DataSourceLookUp.ToValue(item);
+            return properties;
+        }
     }
 }

--- a/DatabaseOperations/ConnectionRules/DatabaseConnectionRule.cs
+++ b/DatabaseOperations/ConnectionRules/DatabaseConnectionRule.cs
@@ -21,5 +21,13 @@
             if (string.IsNullOrWhiteSpace(options.DatabaseName)) options.DatabaseName = DatabaseLookUp.ToValue(item);
             return options;
         }
+
+        public ConnectionProperties ApplyChange(
+            ConnectionProperties properties,
+            string item)
+        {
+            if (string.IsNullOrWhiteSpace(properties.DatabaseName)) properties.DatabaseName = DatabaseLookUp.ToValue(item);
+            return properties;
+        }
     }
 }

--- a/DatabaseOperations/ConnectionRules/NetworkAddressConnectionRule.cs
+++ b/DatabaseOperations/ConnectionRules/NetworkAddressConnectionRule.cs
@@ -21,5 +21,13 @@
             if (string.IsNullOrWhiteSpace(options.Server)) options.Server = NetworkAddressLookUp.ToValue(item);
             return options;
         }
+
+        public ConnectionProperties ApplyChange(
+            ConnectionProperties properties,
+            string item)
+        {
+            if (string.IsNullOrWhiteSpace(properties.Server)) properties.Server = NetworkAddressLookUp.ToValue(item);
+            return properties;
+        }
     }
 }

--- a/DatabaseOperations/ConnectionRules/PasswordConnectionRule.cs
+++ b/DatabaseOperations/ConnectionRules/PasswordConnectionRule.cs
@@ -21,5 +21,13 @@
             if (string.IsNullOrWhiteSpace(options.Password)) options.Password = PasswordLookUp.ToValue(item);
             return options;
         }
+
+        public ConnectionProperties ApplyChange(
+            ConnectionProperties properties,
+            string item)
+        {
+            if (string.IsNullOrWhiteSpace(properties.Password)) properties.Password = PasswordLookUp.ToValue(item);
+            return properties;
+        }
     }
 }

--- a/DatabaseOperations/ConnectionRules/SecurityConnectionRule.cs
+++ b/DatabaseOperations/ConnectionRules/SecurityConnectionRule.cs
@@ -22,5 +22,14 @@
                 options.IntegratedSecurity = IntegratedSecurityLookUp.ToValue(item);
             return options;
         }
+
+        public ConnectionProperties ApplyChange(
+            ConnectionProperties properties,
+            string item)
+        {
+            if (string.IsNullOrWhiteSpace(properties.IntegratedSecurity))
+                properties.IntegratedSecurity = IntegratedSecurityLookUp.ToValue(item);
+            return properties;
+        }
     }
 }

--- a/DatabaseOperations/ConnectionRules/ServerConnectionRule.cs
+++ b/DatabaseOperations/ConnectionRules/ServerConnectionRule.cs
@@ -21,5 +21,13 @@
             if (string.IsNullOrWhiteSpace(options.Server)) options.Server = ServerLookUp.ToValue(item);
             return options;
         }
+
+        public ConnectionProperties ApplyChange(
+            ConnectionProperties properties,
+            string item)
+        {
+            if (string.IsNullOrWhiteSpace(properties.Server)) properties.Server = ServerLookUp.ToValue(item);
+            return properties;
+        }
     }
 }

--- a/DatabaseOperations/ConnectionRules/TrustedConnectionRule.cs
+++ b/DatabaseOperations/ConnectionRules/TrustedConnectionRule.cs
@@ -22,5 +22,14 @@
                 options.IntegratedSecurity = TrustedConnectionLookUp.ToValue(item);
             return options;
         }
+
+        public ConnectionProperties ApplyChange(
+            ConnectionProperties properties,
+            string item)
+        {
+            if (string.IsNullOrWhiteSpace(properties.IntegratedSecurity))
+                properties.IntegratedSecurity = TrustedConnectionLookUp.ToValue(item);
+            return properties;
+        }
     }
 }

--- a/DatabaseOperations/ConnectionRules/UserConnectionRule.cs
+++ b/DatabaseOperations/ConnectionRules/UserConnectionRule.cs
@@ -21,5 +21,13 @@
             if (string.IsNullOrWhiteSpace(options.UserId)) options.UserId = UserIdLookUp.ToValue(item);
             return options;
         }
+
+        public ConnectionProperties ApplyChange(
+            ConnectionProperties properties,
+            string item)
+        {
+            if (string.IsNullOrWhiteSpace(properties.UserId)) properties.UserId = UserIdLookUp.ToValue(item);
+            return properties;
+        }
     }
 }

--- a/DatabaseOperations/DataTransferObjects/BackupProperties.cs
+++ b/DatabaseOperations/DataTransferObjects/BackupProperties.cs
@@ -1,0 +1,14 @@
+﻿namespace DatabaseOperations.DataTransferObjects
+{
+    using Microsoft.Data.SqlClient;
+
+    internal struct BackupProperties
+    {
+        internal SqlParameter[] BackupParameters { get; set; }
+        internal SqlParameter[] ExecutionParameters { get; set; }
+        internal string BackupLocation { get; set; }
+        internal string BackupPath { get; set; }
+        internal string Description { get; set; }
+        internal int CommandTimeout { get; set; }
+    }
+}

--- a/DatabaseOperations/DataTransferObjects/BackupProperties.cs
+++ b/DatabaseOperations/DataTransferObjects/BackupProperties.cs
@@ -1,14 +1,20 @@
 ﻿namespace DatabaseOperations.DataTransferObjects
 {
+    using System.IO;
     using Microsoft.Data.SqlClient;
 
     internal struct BackupProperties
     {
         internal SqlParameter[] BackupParameters { get; set; }
         internal SqlParameter[] ExecutionParameters { get; set; }
-        internal string BackupLocation { get; set; }
+        internal string BackupFileName { get; set; }
         internal string BackupPath { get; set; }
         internal string Description { get; set; }
         internal int CommandTimeout { get; set; }
+
+        internal string BackupPathAndFileName()
+        {
+            return Path.Combine(BackupPath, BackupFileName);
+        }
     }
 }

--- a/DatabaseOperations/DataTransferObjects/ConnectionProperties.cs
+++ b/DatabaseOperations/DataTransferObjects/ConnectionProperties.cs
@@ -1,0 +1,14 @@
+﻿namespace DatabaseOperations.DataTransferObjects
+{
+    internal struct ConnectionProperties
+    {
+        internal string ConnectionString { get; set; }
+        internal string ApplicationName { get; set; }
+        internal string DatabaseName { get; set; }
+        internal string ConnectTimeout { get; set; }
+        internal string IntegratedSecurity { get; set; }
+        internal string Password { get; set; }
+        internal string Server { get; set; }
+        internal string UserId { get; set; }
+    }
+}

--- a/DatabaseOperations/DataTransferObjects/ConnectionProperties.cs
+++ b/DatabaseOperations/DataTransferObjects/ConnectionProperties.cs
@@ -1,14 +1,14 @@
 ﻿namespace DatabaseOperations.DataTransferObjects
 {
-    public struct ConnectionProperties
+    public class ConnectionProperties
     {
-        internal string ConnectionString { get; set; }
-        internal string ApplicationName { get; set; }
-        internal string DatabaseName { get; set; }
-        internal string ConnectTimeout { get; set; }
-        internal string IntegratedSecurity { get; set; }
-        internal string Password { get; set; }
-        internal string Server { get; set; }
-        internal string UserId { get; set; }
+        internal string ConnectionString { get; set; } = string.Empty;
+        internal string ApplicationName { get; set; } = string.Empty;
+        internal string DatabaseName { get; set; } = string.Empty;
+        internal string ConnectTimeout { get; set; } = string.Empty;
+        internal string IntegratedSecurity { get; set; } = string.Empty;
+        internal string Password { get; set; } = string.Empty;
+        internal string Server { get; set; } = string.Empty;
+        internal string UserId { get; set; } = string.Empty;
     }
 }

--- a/DatabaseOperations/DataTransferObjects/ConnectionProperties.cs
+++ b/DatabaseOperations/DataTransferObjects/ConnectionProperties.cs
@@ -1,6 +1,6 @@
 ﻿namespace DatabaseOperations.DataTransferObjects
 {
-    internal struct ConnectionProperties
+    public struct ConnectionProperties
     {
         internal string ConnectionString { get; set; }
         internal string ApplicationName { get; set; }

--- a/DatabaseOperations/Executors/SqlExecutor.cs
+++ b/DatabaseOperations/Executors/SqlExecutor.cs
@@ -55,6 +55,30 @@ WITH
             return result;
         }
 
+        public OperationResult ExecuteBackupPath(
+            OperationResult result,
+            ConnectionProperties connectionProperties,
+            BackupProperties backupProperties)
+        {
+            try
+            {
+                using ISqlConnectionWrapper connection = sqlCreator.CreateConnection(connectionProperties.ConnectionString);
+                using ISqlCommandWrapper command = sqlCreator.CreateCommand(SqlScriptCreateBackupPathTemplate, connection);
+                command.AddParameters(backupProperties.BackupParameters);
+                command.SetCommandTimeout(backupProperties.CommandTimeout);
+                connection.Open();
+                command.ExecuteNonQuery();
+            }
+            catch (DbException exception)
+            {
+                result.Result = false;
+                result.Messages.Add(
+                    $"Backup path folder check/create failed due to an exception.  Exception: {exception.Message}");
+            }
+
+            return result;
+        }
+
         public async Task<OperationResult> ExecuteBackupPathAsync(
             OperationResult result,
             ConnectionOptions options,

--- a/DatabaseOperations/Executors/SqlExecutor.cs
+++ b/DatabaseOperations/Executors/SqlExecutor.cs
@@ -127,6 +127,29 @@ WITH
             return result;
         }
 
+        public OperationResult ExecuteBackupDatabase(
+            OperationResult result,
+            ConnectionProperties connectionProperties,
+            BackupProperties backupProperties)
+        {
+            try
+            {
+                using ISqlConnectionWrapper connection = sqlCreator.CreateConnection(connectionProperties.ConnectionString);
+                using ISqlCommandWrapper command = sqlCreator.CreateCommand(SqlScriptBackupDatabaseTemplate, connection);
+                command.AddParameters(backupProperties.ExecutionParameters);
+                command.SetCommandTimeout(backupProperties.CommandTimeout);
+                connection.Open();
+                command.ExecuteNonQuery();
+            }
+            catch (DbException exception)
+            {
+                result.Result = false;
+                result.Messages.Add($"Backing up the database failed due to an exception.  Exception: {exception.Message}");
+            }
+
+            return result;
+        }
+
         public async Task<OperationResult> ExecuteBackupDatabaseAsync(
             OperationResult result,
             ConnectionOptions options,

--- a/DatabaseOperations/Extensions/OperationResultExtensions.cs
+++ b/DatabaseOperations/Extensions/OperationResultExtensions.cs
@@ -4,7 +4,9 @@
     using System.Threading;
     using System.Threading.Tasks;
     using DataTransferObjects;
+    using FluentValidation.Results;
     using Interfaces;
+    using Validators;
 
     internal static class OperationResultExtensions
     {
@@ -19,6 +21,23 @@
 
             operationResult.Result = false;
             operationResult.Messages = options.Messages;
+            return operationResult;
+        }
+
+        internal static OperationResult ValidateConnectionProperties(
+            this OperationResult operationResult,
+            ConnectionProperties properties)
+        {
+            ValidationResult validationResult = properties.CheckValidation(new ConnectionPropertiesValidator());
+
+            operationResult.Result = validationResult.IsValid;
+            if (validationResult.IsValid) return operationResult;
+
+            foreach (ValidationFailure validationResultError in validationResult.Errors)
+            {
+                operationResult.Messages.Add(validationResultError.ErrorMessage);
+            }
+
             return operationResult;
         }
 

--- a/DatabaseOperations/Extensions/OperationResultExtensions.cs
+++ b/DatabaseOperations/Extensions/OperationResultExtensions.cs
@@ -35,9 +35,7 @@
             if (validationResult.IsValid) return operationResult;
 
             foreach (ValidationFailure validationResultError in validationResult.Errors)
-            {
                 operationResult.Messages.Add(validationResultError.ErrorMessage);
-            }
 
             return operationResult;
         }
@@ -94,6 +92,17 @@
             ISqlExecutor sqlExecutor)
         {
             return !operationResult.Result ? operationResult : sqlExecutor.ExecuteBackupDatabase(operationResult, options);
+        }
+
+        internal static OperationResult ExecuteBackup(
+            this OperationResult operationResult,
+            ConnectionProperties connectionProperties,
+            BackupProperties backupProperties,
+            ISqlExecutor sqlExecutor)
+        {
+            return !operationResult.Result
+                ? operationResult
+                : sqlExecutor.ExecuteBackupDatabase(operationResult, connectionProperties, backupProperties);
         }
 
         internal static async Task<OperationResult> ValidateConnectionOptionsAsync(

--- a/DatabaseOperations/Extensions/OperationResultExtensions.cs
+++ b/DatabaseOperations/Extensions/OperationResultExtensions.cs
@@ -49,6 +49,17 @@
             return !operationResult.Result ? operationResult : sqlExecutor.ExecuteBackupPath(operationResult, options);
         }
 
+        internal static OperationResult ExecuteBackupPath(
+            this OperationResult operationResult,
+            ConnectionProperties connectionProperties,
+            BackupProperties backupProperties,
+            ISqlExecutor sqlExecutor)
+        {
+            return !operationResult.Result
+                ? operationResult
+                : sqlExecutor.ExecuteBackupPath(operationResult, connectionProperties, backupProperties);
+        }
+
         internal static OperationResult CheckBackupPathExecution(
             this OperationResult operationResult,
             ConnectionOptions options)

--- a/DatabaseOperations/Extensions/OperationResultExtensions.cs
+++ b/DatabaseOperations/Extensions/OperationResultExtensions.cs
@@ -6,6 +6,7 @@
     using DataTransferObjects;
     using FluentValidation.Results;
     using Interfaces;
+    using Services;
     using Validators;
 
     internal static class OperationResultExtensions
@@ -69,6 +70,20 @@
             operationResult.Result = true;
             operationResult.Messages.Add(BackupPathCheckFailureMessage);
             options.RemovePathFromBackupLocation();
+
+            return operationResult;
+        }
+
+        internal static OperationResult CheckBackupPathExecution(
+            this OperationResult operationResult,
+            ConnectionProperties connectionProperties,
+            BackupProperties backupProperties)
+        {
+            if (!operationResult.Messages.Any()) return operationResult;
+
+            operationResult.Result = true;
+            operationResult.Messages.Add(BackupPathCheckFailureMessage);
+            backupProperties.SetExecutorToUseFileNameOnly(connectionProperties);
 
             return operationResult;
         }

--- a/DatabaseOperations/Extensions/ValidationExtensions.cs
+++ b/DatabaseOperations/Extensions/ValidationExtensions.cs
@@ -7,7 +7,7 @@
     {
         internal static ValidationResult CheckValidation<T>(
             this T component,
-            AbstractValidator<T> validator) where T : class
+            AbstractValidator<T> validator)
         {
             ValidationResult? result = validator.Validate(component);
             return result;

--- a/DatabaseOperations/Interfaces/IBackupOperator.cs
+++ b/DatabaseOperations/Interfaces/IBackupOperator.cs
@@ -4,6 +4,7 @@
     using System.Threading;
     using System.Threading.Tasks;
     using DataTransferObjects;
+    using Options;
 
     /// <summary>
     ///     This is the 'backup' <see langword="interface" /> for the operators.
@@ -24,6 +25,27 @@
         ///     The result of the backup operation.
         /// </returns>
         OperationResult BackupDatabase(ConnectionOptions options);
+
+        /// <summary>
+        ///     Uses the connection string and options defined by the user to start
+        ///     the backup process.
+        /// </summary>
+        /// <param name="connectionString">
+        ///     The connection string defined by the consumer of the method.
+        /// </param>
+        /// <param name="options">
+        ///     The additional options defined by the consumer of the method. Otherwise the
+        ///     default settings will be used.
+        /// </param>
+        /// <exception cref="NotSupportedException">
+        ///     The database exception was not added to the 'Message' list.
+        /// </exception>
+        /// <returns>
+        ///     The result of the backup operation.
+        /// </returns>
+        OperationResult BackupDatabase(
+            string connectionString,
+            Action<OperatorOptions>? options = null);
 
         /// <summary>
         ///     Uses the <paramref name="options" /> defined by the user to start

--- a/DatabaseOperations/Interfaces/IBackupOperator.cs
+++ b/DatabaseOperations/Interfaces/IBackupOperator.cs
@@ -65,5 +65,28 @@
         Task<OperationResult> BackupDatabaseAsync(
             ConnectionOptions options,
             CancellationToken token);
+
+        /// <summary>
+        ///     Uses the <paramref name="connectionString" /> and <paramref name="options" /> defined by the user to start
+        ///     the backup process.
+        ///     This is the async version.
+        /// </summary>
+        /// <param name="connectionString">
+        ///     The connection string defined by the consumer of the method.
+        /// </param>
+        /// <param name="options">
+        ///     The connection options defined by the consumer of the method.
+        /// </param>
+        /// <param name="token"> The cancellation token supplied by the calling application. </param>
+        /// <exception cref="NotSupportedException">
+        ///     The database exception was not added to the 'Message' list.
+        /// </exception>
+        /// <returns>
+        ///     The result of the backup operation.
+        /// </returns>
+        Task<OperationResult> BackupDatabaseAsync(
+            string connectionString,
+            Action<OperatorOptions>? options = null,
+            CancellationToken token = default);
     }
 }

--- a/DatabaseOperations/Interfaces/IConnectionRule.cs
+++ b/DatabaseOperations/Interfaces/IConnectionRule.cs
@@ -9,5 +9,9 @@
         ConnectionOptions ApplyChange(
             ConnectionOptions options,
             string item);
+
+        ConnectionProperties ApplyChange(
+            ConnectionProperties properties,
+            string item);
     }
 }

--- a/DatabaseOperations/Interfaces/ISqlExecutor.cs
+++ b/DatabaseOperations/Interfaces/ISqlExecutor.cs
@@ -20,6 +20,12 @@
             ConnectionOptions options,
             CancellationToken token);
 
+        Task<OperationResult> ExecuteBackupPathAsync(
+            OperationResult result,
+            ConnectionProperties connectionProperties,
+            BackupProperties backupProperties,
+            CancellationToken token);
+
         OperationResult ExecuteBackupDatabase(
             OperationResult result,
             ConnectionOptions options);
@@ -32,6 +38,12 @@
         Task<OperationResult> ExecuteBackupDatabaseAsync(
             OperationResult result,
             ConnectionOptions options,
+            CancellationToken token);
+
+        Task<OperationResult> ExecuteBackupDatabaseAsync(
+            OperationResult result,
+            ConnectionProperties connectionProperties,
+            BackupProperties backupProperties,
             CancellationToken token);
     }
 }

--- a/DatabaseOperations/Interfaces/ISqlExecutor.cs
+++ b/DatabaseOperations/Interfaces/ISqlExecutor.cs
@@ -10,6 +10,11 @@
             OperationResult result,
             ConnectionOptions options);
 
+        OperationResult ExecuteBackupPath(
+            OperationResult result,
+            ConnectionProperties connectionProperties,
+            BackupProperties backupProperties);
+
         Task<OperationResult> ExecuteBackupPathAsync(
             OperationResult result,
             ConnectionOptions options,

--- a/DatabaseOperations/Interfaces/ISqlExecutor.cs
+++ b/DatabaseOperations/Interfaces/ISqlExecutor.cs
@@ -24,6 +24,11 @@
             OperationResult result,
             ConnectionOptions options);
 
+        OperationResult ExecuteBackupDatabase(
+            OperationResult result,
+            ConnectionProperties connectionProperties,
+            BackupProperties backupProperties);
+
         Task<OperationResult> ExecuteBackupDatabaseAsync(
             OperationResult result,
             ConnectionOptions options,

--- a/DatabaseOperations/Operators/BackupOperator.cs
+++ b/DatabaseOperations/Operators/BackupOperator.cs
@@ -116,7 +116,8 @@
             options?.Invoke(optionsToUse);
             ConnectionProperties properties = ConnectionStringService.ExtractConnectionParameters(connectionString);
 
-            OperationResult result = new();
+            OperationResult result = new OperationResult()
+                .ValidateConnectionProperties(properties);
             //.ValidateConnectionOptions(options)
             //.ExecuteBackupPath(options, sqlExecutor)
             //.CheckBackupPathExecution(options)

--- a/DatabaseOperations/Operators/BackupOperator.cs
+++ b/DatabaseOperations/Operators/BackupOperator.cs
@@ -120,9 +120,8 @@
             OperationResult result = new OperationResult()
                 .ValidateConnectionProperties(connectionProperties)
                 .ExecuteBackupPath(connectionProperties, backupProperties, sqlExecutor)
-                .CheckBackupPathExecution(connectionProperties, backupProperties);
-
-            //.ExecuteBackup(options, sqlExecutor);
+                .CheckBackupPathExecution(connectionProperties, backupProperties)
+                .ExecuteBackup(connectionProperties, backupProperties, sqlExecutor);
 
             return result;
         }

--- a/DatabaseOperations/Operators/BackupOperator.cs
+++ b/DatabaseOperations/Operators/BackupOperator.cs
@@ -114,7 +114,7 @@
         {
             OperatorOptions optionsToUse = new();
             options?.Invoke(optionsToUse);
-            ConnectionStringService service = new(connectionString);
+            ConnectionProperties properties = ConnectionStringService.ExtractConnectionParameters(connectionString);
 
             OperationResult result = new();
             //.ValidateConnectionOptions(options)

--- a/DatabaseOperations/Operators/BackupOperator.cs
+++ b/DatabaseOperations/Operators/BackupOperator.cs
@@ -114,10 +114,13 @@
         {
             OperatorOptions optionsToUse = new();
             options?.Invoke(optionsToUse);
-            ConnectionProperties properties = ConnectionStringService.ExtractConnectionParameters(connectionString);
+            ConnectionProperties connectionProperties = ConnectionStringService.ExtractConnectionParameters(connectionString);
+            BackupProperties backupProperties = BackupParameterService.GetBackupProperties(connectionProperties, optionsToUse);
 
             OperationResult result = new OperationResult()
-                .ValidateConnectionProperties(properties);
+                .ValidateConnectionProperties(connectionProperties)
+                .ExecuteBackupPath(connectionProperties, backupProperties, sqlExecutor);
+
             //.ValidateConnectionOptions(options)
             //.ExecuteBackupPath(options, sqlExecutor)
             //.CheckBackupPathExecution(options)

--- a/DatabaseOperations/Operators/BackupOperator.cs
+++ b/DatabaseOperations/Operators/BackupOperator.cs
@@ -119,11 +119,9 @@
 
             OperationResult result = new OperationResult()
                 .ValidateConnectionProperties(connectionProperties)
-                .ExecuteBackupPath(connectionProperties, backupProperties, sqlExecutor);
+                .ExecuteBackupPath(connectionProperties, backupProperties, sqlExecutor)
+                .CheckBackupPathExecution(connectionProperties, backupProperties);
 
-            //.ValidateConnectionOptions(options)
-            //.ExecuteBackupPath(options, sqlExecutor)
-            //.CheckBackupPathExecution(options)
             //.ExecuteBackup(options, sqlExecutor);
 
             return result;

--- a/DatabaseOperations/Operators/BackupOperator.cs
+++ b/DatabaseOperations/Operators/BackupOperator.cs
@@ -8,6 +8,8 @@
     using Extensions;
     using Factories;
     using Interfaces;
+    using Options;
+    using Services;
 
     /// <summary>
     ///     This is the 'backup' class of operators.
@@ -86,6 +88,39 @@
                 .ExecuteBackupAsync(options, token, sqlExecutor)
                 .CheckForCancellation(token)
                 .ConfigureAwait(false);
+
+            return result;
+        }
+
+        /// <summary>
+        ///     Uses the <paramref name="options" /> defined by the user to start
+        ///     the backup process.
+        /// </summary>
+        /// <param name="connectionString">
+        ///     The connection string defined by the consumer of the method.
+        /// </param>
+        /// <param name="options">
+        ///     The defined options required by the consumer of the method.
+        /// </param>
+        /// <exception cref="NotSupportedException">
+        ///     The database exception was not added to the 'Message' list.
+        /// </exception>
+        /// <returns>
+        ///     The result of the backup operation.
+        /// </returns>
+        public OperationResult BackupDatabase(
+            string connectionString,
+            Action<OperatorOptions>? options = null)
+        {
+            OperatorOptions optionsToUse = new();
+            options?.Invoke(optionsToUse);
+            ConnectionStringService service = new(connectionString);
+
+            OperationResult result = new();
+            //.ValidateConnectionOptions(options)
+            //.ExecuteBackupPath(options, sqlExecutor)
+            //.CheckBackupPathExecution(options)
+            //.ExecuteBackup(options, sqlExecutor);
 
             return result;
         }

--- a/DatabaseOperations/Operators/BackupOperator.cs
+++ b/DatabaseOperations/Operators/BackupOperator.cs
@@ -60,6 +60,40 @@
         }
 
         /// <summary>
+        ///     Uses the <paramref name="connectionString" /> and <paramref name="options" /> defined by the user to start
+        ///     the backup process.
+        /// </summary>
+        /// <param name="connectionString">
+        ///     The connection string defined by the consumer of the method.
+        /// </param>
+        /// <param name="options">
+        ///     The defined options required by the consumer of the method.
+        /// </param>
+        /// <exception cref="NotSupportedException">
+        ///     The database exception was not added to the 'Message' list.
+        /// </exception>
+        /// <returns>
+        ///     The result of the backup operation.
+        /// </returns>
+        public OperationResult BackupDatabase(
+            string connectionString,
+            Action<OperatorOptions>? options = null)
+        {
+            OperatorOptions optionsToUse = new();
+            options?.Invoke(optionsToUse);
+            ConnectionProperties connectionProperties = ConnectionStringService.ExtractConnectionParameters(connectionString);
+            BackupProperties backupProperties = BackupParameterService.GetBackupProperties(connectionProperties, optionsToUse);
+
+            OperationResult result = new OperationResult()
+                .ValidateConnectionProperties(connectionProperties)
+                .ExecuteBackupPath(connectionProperties, backupProperties, sqlExecutor)
+                .CheckBackupPathExecution(connectionProperties, backupProperties)
+                .ExecuteBackup(connectionProperties, backupProperties, sqlExecutor);
+
+            return result;
+        }
+
+        /// <summary>
         ///     Uses the <paramref name="options" /> defined by the user to start
         ///     the backup process.
         ///     This is the async version.
@@ -93,35 +127,51 @@
         }
 
         /// <summary>
-        ///     Uses the <paramref name="options" /> defined by the user to start
+        ///     Uses the <paramref name="connectionString" /> and <paramref name="options" /> defined by the user to start
         ///     the backup process.
+        ///     This is the async version.
         /// </summary>
         /// <param name="connectionString">
         ///     The connection string defined by the consumer of the method.
         /// </param>
         /// <param name="options">
-        ///     The defined options required by the consumer of the method.
+        ///     The connection options defined by the consumer of the method.
         /// </param>
+        /// <param name="token"> The cancellation token supplied by the calling application. </param>
         /// <exception cref="NotSupportedException">
         ///     The database exception was not added to the 'Message' list.
         /// </exception>
         /// <returns>
         ///     The result of the backup operation.
         /// </returns>
-        public OperationResult BackupDatabase(
+        public async Task<OperationResult> BackupDatabaseAsync(
             string connectionString,
-            Action<OperatorOptions>? options = null)
+            Action<OperatorOptions>? options = null,
+            CancellationToken token = default)
         {
             OperatorOptions optionsToUse = new();
             options?.Invoke(optionsToUse);
             ConnectionProperties connectionProperties = ConnectionStringService.ExtractConnectionParameters(connectionString);
             BackupProperties backupProperties = BackupParameterService.GetBackupProperties(connectionProperties, optionsToUse);
 
-            OperationResult result = new OperationResult()
-                .ValidateConnectionProperties(connectionProperties)
-                .ExecuteBackupPath(connectionProperties, backupProperties, sqlExecutor)
-                .CheckBackupPathExecution(connectionProperties, backupProperties)
-                .ExecuteBackup(connectionProperties, backupProperties, sqlExecutor);
+            OperationResult result = await new OperationResult()
+                .ValidateConnectionPropertiesAsync(connectionProperties)
+                .CheckForCancellation(token)
+                .ExecuteBackupPathAsync(
+                    connectionProperties,
+                    backupProperties,
+                    token,
+                    sqlExecutor)
+                .CheckForCancellation(token)
+                .CheckBackupPathExecutionAsync(connectionProperties, backupProperties, token)
+                .CheckForCancellation(token)
+                .ExecuteBackupAsync(
+                    connectionProperties,
+                    backupProperties,
+                    token,
+                    sqlExecutor)
+                .CheckForCancellation(token)
+                .ConfigureAwait(false);
 
             return result;
         }

--- a/DatabaseOperations/Options/OperatorOptions.cs
+++ b/DatabaseOperations/Options/OperatorOptions.cs
@@ -1,0 +1,17 @@
+﻿namespace DatabaseOperations.Options
+{
+    public class OperatorOptions
+    {
+        public string BackupPath { get; set; } = string.Empty;
+        public int Timeout { get; set; } = 0;
+
+        //public string BackupFileForRestore { get; set; } = string.Empty;
+        //public string DatabaseBackupName { get; set; } = string.Empty;
+        //public string DatabaseSnapShotName { get; set; } = string.Empty;
+        //public bool UseDisk { get; set; } = true;
+        //public bool WithRecovery { get; set; } = true;
+        //public bool WithReplace { get; set; } = true;
+        //public bool WithRestart { get; set; } = false;
+        //public bool VerifyOnly { get; set; } = false;
+    }
+}

--- a/DatabaseOperations/Services/BackupParameterService.cs
+++ b/DatabaseOperations/Services/BackupParameterService.cs
@@ -27,6 +27,18 @@
             return GetBackupProperties(connectionOptions, operatorOptions, dateTimeWrapper);
         }
 
+        internal static BackupProperties SetExecutorToUseFileNameOnly(
+            this BackupProperties backupProperties,
+            ConnectionProperties connectionProperties)
+        {
+            backupProperties.ExecutionParameters = GetParameters(
+                connectionProperties.DatabaseName,
+                backupProperties.BackupFileName,
+                backupProperties.Description);
+
+            return backupProperties;
+        }
+
         private static BackupProperties GetBackupProperties(
             ConnectionProperties connectionOptions,
             OperatorOptions operatorOptions,
@@ -35,17 +47,17 @@
             BackupProperties backupProperties = new();
 
             string location =
-                $"{operatorOptions.BackupPath}{connectionOptions.DatabaseName}_Full_{dateTimeWrapper.Now:yyyy-MM-dd-HH-mm-ss}.bak";
+                $"{connectionOptions.DatabaseName}_Full_{dateTimeWrapper.Now:yyyy-MM-dd-HH-mm-ss}.bak";
             string description = $"Full backup of the `{connectionOptions.DatabaseName}` database.";
 
-            backupProperties.BackupLocation = location;
+            backupProperties.BackupFileName = location;
             backupProperties.Description = description;
             backupProperties.BackupPath = operatorOptions.BackupPath;
             backupProperties.CommandTimeout = SetDefaultOrTimeout(operatorOptions.Timeout);
             backupProperties.BackupParameters = GetBackupParameters(operatorOptions.BackupPath);
             backupProperties.ExecutionParameters = GetParameters(
                 connectionOptions.DatabaseName,
-                backupProperties.BackupLocation,
+                backupProperties.BackupPathAndFileName(),
                 backupProperties.Description);
 
             return backupProperties;

--- a/DatabaseOperations/Services/BackupParameterService.cs
+++ b/DatabaseOperations/Services/BackupParameterService.cs
@@ -11,20 +11,20 @@
     internal static class BackupParameterService
     {
         internal static BackupProperties GetBackupProperties(
-            ConnectionProperties connectionOptions,
+            ConnectionProperties connectionProperties,
             OperatorOptions operatorOptions)
         {
             IDateTimeWrapper dateTimeWrapper = new DateTimeWrapper();
-            return GetBackupProperties(connectionOptions, operatorOptions, dateTimeWrapper);
+            return GetBackupProperties(connectionProperties, operatorOptions, dateTimeWrapper);
         }
 
         internal static BackupProperties GetBackupPropertiesForTests(
-            ConnectionProperties connectionOptions,
+            ConnectionProperties connectionProperties,
             OperatorOptions operatorOptions,
             IDateTimeWrapper dateTimeWrapper
         )
         {
-            return GetBackupProperties(connectionOptions, operatorOptions, dateTimeWrapper);
+            return GetBackupProperties(connectionProperties, operatorOptions, dateTimeWrapper);
         }
 
         internal static BackupProperties SetExecutorToUseFileNameOnly(
@@ -40,15 +40,15 @@
         }
 
         private static BackupProperties GetBackupProperties(
-            ConnectionProperties connectionOptions,
+            ConnectionProperties connectionProperties,
             OperatorOptions operatorOptions,
             IDateTimeWrapper dateTimeWrapper)
         {
             BackupProperties backupProperties = new();
 
             string location =
-                $"{connectionOptions.DatabaseName}_Full_{dateTimeWrapper.Now:yyyy-MM-dd-HH-mm-ss}.bak";
-            string description = $"Full backup of the `{connectionOptions.DatabaseName}` database.";
+                $"{connectionProperties.DatabaseName}_Full_{dateTimeWrapper.Now:yyyy-MM-dd-HH-mm-ss}.bak";
+            string description = $"Full backup of the `{connectionProperties.DatabaseName}` database.";
 
             backupProperties.BackupFileName = location;
             backupProperties.Description = description;
@@ -56,7 +56,7 @@
             backupProperties.CommandTimeout = SetDefaultOrTimeout(operatorOptions.Timeout);
             backupProperties.BackupParameters = GetBackupParameters(operatorOptions.BackupPath);
             backupProperties.ExecutionParameters = GetParameters(
-                connectionOptions.DatabaseName,
+                connectionProperties.DatabaseName,
                 backupProperties.BackupPathAndFileName(),
                 backupProperties.Description);
 

--- a/DatabaseOperations/Services/BackupParameterService.cs
+++ b/DatabaseOperations/Services/BackupParameterService.cs
@@ -1,0 +1,80 @@
+﻿namespace DatabaseOperations.Services
+{
+    using System.Data;
+    using Constants;
+    using DataTransferObjects;
+    using Interfaces;
+    using Microsoft.Data.SqlClient;
+    using Options;
+    using Wrappers;
+
+    internal static class BackupParameterService
+    {
+        internal static BackupProperties GetBackupProperties(
+            ConnectionProperties connectionOptions,
+            OperatorOptions operatorOptions)
+        {
+            IDateTimeWrapper dateTimeWrapper = new DateTimeWrapper();
+            return GetBackupProperties(connectionOptions, operatorOptions, dateTimeWrapper);
+        }
+
+        internal static BackupProperties GetBackupPropertiesForTests(
+            ConnectionProperties connectionOptions,
+            OperatorOptions operatorOptions,
+            IDateTimeWrapper dateTimeWrapper
+        )
+        {
+            return GetBackupProperties(connectionOptions, operatorOptions, dateTimeWrapper);
+        }
+
+        private static BackupProperties GetBackupProperties(
+            ConnectionProperties connectionOptions,
+            OperatorOptions operatorOptions,
+            IDateTimeWrapper dateTimeWrapper)
+        {
+            BackupProperties backupProperties = new();
+
+            string location =
+                $"{operatorOptions.BackupPath}{connectionOptions.DatabaseName}_Full_{dateTimeWrapper.Now:yyyy-MM-dd-HH-mm-ss}.bak";
+            string description = $"Full backup of the `{connectionOptions.DatabaseName}` database.";
+
+            backupProperties.BackupLocation = location;
+            backupProperties.Description = description;
+            backupProperties.BackupPath = operatorOptions.BackupPath;
+            backupProperties.CommandTimeout = SetDefaultOrTimeout(operatorOptions.Timeout);
+            backupProperties.BackupParameters = GetBackupParameters(operatorOptions.BackupPath);
+            backupProperties.ExecutionParameters = GetParameters(
+                connectionOptions.DatabaseName,
+                backupProperties.BackupLocation,
+                backupProperties.Description);
+
+            return backupProperties;
+        }
+
+        private static int SetDefaultOrTimeout(int timeout)
+        {
+            return timeout == 0 ? 60 * 60 : timeout;
+        }
+
+        private static SqlParameter[] GetBackupParameters(string backupPath)
+        {
+            SqlParameter pathParameter = new(Parameters.PathParameter, SqlDbType.VarChar) { Value = backupPath };
+
+            return new[] { pathParameter };
+        }
+
+        private static SqlParameter[] GetParameters(
+            string database,
+            string location,
+            string description)
+        {
+            SqlParameter nameParameter = new(Parameters.NameParameter, SqlDbType.VarChar) { Value = database };
+            SqlParameter locationParameter = new(Parameters.LocationParameter, SqlDbType.VarChar)
+                { Value = location };
+            SqlParameter descriptionParameter = new(Parameters.DescriptionParameter, SqlDbType.VarChar)
+                { Value = description };
+
+            return new[] { nameParameter, locationParameter, descriptionParameter };
+        }
+    }
+}

--- a/DatabaseOperations/Services/ConnectionStringService.cs
+++ b/DatabaseOperations/Services/ConnectionStringService.cs
@@ -31,7 +31,7 @@
             new UserConnectionRule()
         };
 
-        private static ConnectionProperties ExtractConnectionParameters(string connectionString)
+        internal static ConnectionProperties ExtractConnectionParameters(string connectionString)
         {
             isValid = !string.IsNullOrWhiteSpace(connectionString);
             if (!isValid) return new ConnectionProperties();

--- a/DatabaseOperations/Services/ConnectionStringService.cs
+++ b/DatabaseOperations/Services/ConnectionStringService.cs
@@ -38,7 +38,7 @@
 
             ConnectionProperties connectionProperties = ProcessItemArray(itemArray);
             connectionProperties.ConnectionString = connectionString;
-            connectionProperties.ConnectionString = UpdateConnectionString(connectionProperties);
+            connectionProperties.ConnectionString = UpdateConnectionString(connectionString, connectionProperties.ConnectTimeout);
             return connectionProperties;
         }
 
@@ -59,11 +59,12 @@
                     connectionRule.ApplyChange(properties, item);
         }
 
-        private static string UpdateConnectionString(ConnectionProperties properties)
+        private static string UpdateConnectionString(string connectionString,
+            string connectTimeout)
         {
-            return !string.IsNullOrWhiteSpace(properties.ConnectTimeout)
-                ? Regex.Replace(properties.ConnectionString, "Connect Timeout=[0-9]{1,3}", "Connect Timeout=5")
-                : properties.ConnectionString;
+            return !string.IsNullOrWhiteSpace(connectTimeout)
+                ? Regex.Replace(connectionString, "Connect Timeout=[0-9]{1,3}", "Connect Timeout=5")
+                : connectionString;
         }
     }
 }

--- a/DatabaseOperations/Services/ConnectionStringService.cs
+++ b/DatabaseOperations/Services/ConnectionStringService.cs
@@ -1,0 +1,69 @@
+﻿namespace DatabaseOperations.Services
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text.RegularExpressions;
+    using ConnectionRules;
+    using DataTransferObjects;
+    using Interfaces;
+
+    internal static class ConnectionStringService
+    {
+        private static readonly char[] SplitArray = { ';' };
+        private static bool isValid;
+
+        private static readonly IList<IConnectionRule> ConnectionRules = new List<IConnectionRule>
+        {
+            new ApplicationConnectionRule(),
+            new ConnectTimeoutConnectionRule(),
+            new ConnectionTimeoutConnectionRule(),
+            new DataSourceConnectionRule(),
+            new ServerConnectionRule(),
+            new AddressConnectionRule(),
+            new AbbreviatedAddressConnectionRule(),
+            new NetworkAddressConnectionRule(),
+            new CatalogConnectionRule(),
+            new DatabaseConnectionRule(),
+            new SecurityConnectionRule(),
+            new TrustedConnectionRule(),
+            new PasswordConnectionRule(),
+            new AbbreviatedPasswordConnectionRule(),
+            new UserConnectionRule()
+        };
+
+        private static ConnectionProperties ExtractConnectionParameters(string connectionString)
+        {
+            isValid = !string.IsNullOrWhiteSpace(connectionString);
+            if (!isValid) return new ConnectionProperties();
+
+            string[] itemArray = connectionString.Split(SplitArray, StringSplitOptions.RemoveEmptyEntries);
+
+            ConnectionProperties connectionProperties = ProcessItemArray(itemArray);
+            connectionProperties.ConnectionString = UpdateConnectionString(connectionProperties);
+            return connectionProperties;
+        }
+
+        private static ConnectionProperties ProcessItemArray(IEnumerable<string> itemArray)
+        {
+            ConnectionProperties properties = new();
+            foreach (string item in itemArray) ApplyConnectionRules(item, properties);
+
+            return properties;
+        }
+
+        private static void ApplyConnectionRules(string item,
+            ConnectionProperties properties)
+        {
+            foreach (IConnectionRule connectionRule in ConnectionRules)
+                if (connectionRule.Check(item))
+                    connectionRule.ApplyChange(properties, item);
+        }
+
+        private static string UpdateConnectionString(ConnectionProperties properties)
+        {
+            return !string.IsNullOrWhiteSpace(properties.ConnectTimeout)
+                ? Regex.Replace(properties.ConnectionString, "Connect Timeout=[0-9]{1,3}", "Connect Timeout=5")
+                : properties.ConnectionString;
+        }
+    }
+}

--- a/DatabaseOperations/Services/ConnectionStringService.cs
+++ b/DatabaseOperations/Services/ConnectionStringService.cs
@@ -49,7 +49,8 @@
             return properties;
         }
 
-        private static void ApplyConnectionRules(string item,
+        private static void ApplyConnectionRules(
+            string item,
             ConnectionProperties properties)
         {
             foreach (IConnectionRule connectionRule in ConnectionRules)

--- a/DatabaseOperations/Services/ConnectionStringService.cs
+++ b/DatabaseOperations/Services/ConnectionStringService.cs
@@ -37,6 +37,7 @@
             string[] itemArray = connectionString.Split(SplitArray, StringSplitOptions.RemoveEmptyEntries);
 
             ConnectionProperties connectionProperties = ProcessItemArray(itemArray);
+            connectionProperties.ConnectionString = connectionString;
             connectionProperties.ConnectionString = UpdateConnectionString(connectionProperties);
             return connectionProperties;
         }

--- a/DatabaseOperations/Services/ConnectionStringService.cs
+++ b/DatabaseOperations/Services/ConnectionStringService.cs
@@ -10,7 +10,6 @@
     internal static class ConnectionStringService
     {
         private static readonly char[] SplitArray = { ';' };
-        private static bool isValid;
 
         private static readonly IList<IConnectionRule> ConnectionRules = new List<IConnectionRule>
         {
@@ -33,8 +32,7 @@
 
         internal static ConnectionProperties ExtractConnectionParameters(string connectionString)
         {
-            isValid = !string.IsNullOrWhiteSpace(connectionString);
-            if (!isValid) return new ConnectionProperties();
+            if (string.IsNullOrWhiteSpace(connectionString)) return new ConnectionProperties();
 
             string[] itemArray = connectionString.Split(SplitArray, StringSplitOptions.RemoveEmptyEntries);
 

--- a/DatabaseOperations/Validators/ConnectionPropertiesValidator.cs
+++ b/DatabaseOperations/Validators/ConnectionPropertiesValidator.cs
@@ -1,0 +1,60 @@
+﻿namespace DatabaseOperations.Validators
+{
+    using DataTransferObjects;
+    using FluentValidation;
+
+    internal class ConnectionPropertiesValidator : AbstractValidator<ConnectionProperties>
+    {
+        public ConnectionPropertiesValidator()
+        {
+            RuleFor(properties => properties)
+                .NotNull();
+            RuleFor(properties => properties.Server)
+                .NotNull()
+                .NotEmpty();
+            RuleFor(properties => properties.DatabaseName)
+                .NotNull()
+                .NotEmpty();
+            RuleFor(properties => properties.ConnectTimeout)
+                .Must(ConnectTimeoutCanNotBeNegative);
+            RuleFor(properties => properties)
+                .Must(UserAndPasswordMustBeSuppliedIfSecurityNotSet);
+            RuleFor(properties => properties.IntegratedSecurity)
+                .Must(SecurityIfSetMustBeOneOfThreeOptions);
+        }
+
+        private static bool ConnectTimeoutCanNotBeNegative(string timeout)
+        {
+            bool result = int.TryParse(timeout, out int convertedTimeout);
+            if (result) result = convertedTimeout >= 0;
+
+            return result;
+        }
+
+        private static bool UserAndPasswordMustBeSuppliedIfSecurityNotSet(ConnectionProperties properties)
+        {
+            if (!string.IsNullOrWhiteSpace(properties.IntegratedSecurity)) return true;
+            bool userSet = !string.IsNullOrWhiteSpace(properties.UserId);
+            bool passwordSet = !string.IsNullOrWhiteSpace(properties.Password);
+
+            bool result = userSet && passwordSet;
+
+            return result;
+        }
+
+        private static bool SecurityIfSetMustBeOneOfThreeOptions(string integratedSecurity)
+        {
+            if (string.IsNullOrWhiteSpace(integratedSecurity)) return true;
+
+            bool result = integratedSecurity.ToLower() switch
+            {
+                "true" => true,
+                "false" => true,
+                "sspi" => true,
+                _ => false
+            };
+
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
- Added an overload to the backup methods
- The overload now accepts the options using an `action`
- Unit tests have been added to cover the overloads

Readme and wiki changes to come with the test app repo.