### PR TITLE
Update NuGet packages - for vulnerabilities

### DIFF
--- a/DatabaseOperations.Tests/DatabaseOperations.Tests.csproj
+++ b/DatabaseOperations.Tests/DatabaseOperations.Tests.csproj
@@ -8,18 +8,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="FluentAssertions" Version="6.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NSubstitute" Version="4.4.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -27,6 +27,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DatabaseOperations\DatabaseOperations.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.5.119" />
   </ItemGroup>
 
 </Project>

--- a/DatabaseOperations.Tests/Services/ConnectionStringServiceTests.cs
+++ b/DatabaseOperations.Tests/Services/ConnectionStringServiceTests.cs
@@ -130,7 +130,7 @@
                 .Be(expectedConnection);
         }
 
-        internal static IEnumerable<object[]> ConnectionStrings()
+        public static IEnumerable<object[]> ConnectionStrings()
         {
             yield return new object[]
             {
@@ -190,7 +190,7 @@
             };
         }
 
-        internal static IEnumerable<object[]> UserConnectionStrings()
+        public static IEnumerable<object[]> UserConnectionStrings()
         {
             yield return new object[]
             {
@@ -226,7 +226,7 @@
             };
         }
 
-        internal static IEnumerable<object[]> TrustedConnectionStrings()
+        public static IEnumerable<object[]> TrustedConnectionStrings()
         {
             yield return new object[]
             {

--- a/DatabaseOperations.Tests/Validators/ConnectionPropertiesValidatorTests.cs
+++ b/DatabaseOperations.Tests/Validators/ConnectionPropertiesValidatorTests.cs
@@ -101,7 +101,7 @@
                 .BeFalse();
         }
 
-        internal static IEnumerable<object[]> ConnectionProperties()
+        public static IEnumerable<object[]> ConnectionProperties()
         {
             yield return new object[]
             {

--- a/DatabaseOperations/DatabaseOperations.csproj
+++ b/DatabaseOperations/DatabaseOperations.csproj
@@ -41,8 +41,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="11.1.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="4.1.0" />
+    <PackageReference Include="FluentValidation" Version="11.2.2" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.0.1" />
+    <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="Useful.Extensions" Version="3.0.2" />
@@ -51,6 +52,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.5.119" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Small tweak to test projects as xUnit required `public` methods.
Fixes #75 